### PR TITLE
branding: UAVCAN -> OpenCyphal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,10 @@
 The library is intended for use in real-time high-integrity applications.
 It is paramount that its temporal properties and resource utilization are plain to model and predict statically.
 The code shall follow applicable high-reliability coding guidelines as explained later in this document.
-The implementation shall be fully compliant with the UAVCAN/CAN specification.
+The implementation shall be fully compliant with the Cyphal/CAN specification.
 
 The implementation and the API should be kept simple.
-There will be no high-level abstractions -- if that is desired, other implementations of UAVCAN should be used.
+There will be no high-level abstractions -- if that is desired, other implementations of Cyphal should be used.
 
 The library is intended for deeply embedded systems where the resources may be scarce.
 The ROM footprint is of a particular concern because the library should be usable with embedded bootloaders.
@@ -83,7 +83,7 @@ To reformat the sources, generate the project and build the target `format`; e.g
 ### SonarQube
 
 SonarQube is a cloud solution so its use is delegated to the CI/CD pipeline.
-If you need access, please get in touch with the UAVCAN Development Team members.
+If you need access, please get in touch with the OpenCyphal Development Team members.
 
 ### IDE
 
@@ -106,4 +106,4 @@ Never use `REQUIRE` etc. anywhere but the main thread.
 
 ## Releasing
 
-Simply create a new release on GitHub: <https://github.com/UAVCAN/libcanard/releases/new>
+Simply create a new release on GitHub: <https://github.com/OpenCyphal/libcanard/releases/new>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2020 UAVCAN Development Team
+Copyright (c) 2016-2020 Cyphal Development Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,30 +1,29 @@
-# Compact UAVCAN/CAN v1 in C
+# Compact Cyphal/CAN v1 in C
 
-[![Main Workflow](https://github.com/UAVCAN/libcanard/actions/workflows/main.yml/badge.svg)](https://github.com/UAVCAN/libcanard/actions/workflows/main.yml)
+[![Main Workflow](https://github.com/OpenCyphal/libcanard/actions/workflows/main.yml/badge.svg)](https://github.com/OpenCyphal/libcanard/actions/workflows/main.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=libcanard&metric=alert_status)](https://sonarcloud.io/dashboard?id=libcanard)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=libcanard&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=libcanard)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=libcanard&metric=coverage)](https://sonarcloud.io/dashboard?id=libcanard)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=libcanard&metric=ncloc)](https://sonarcloud.io/dashboard?id=libcanard)
-[![Forum](https://img.shields.io/discourse/users.svg?server=https%3A%2F%2Fforum.uavcan.org&color=1700b3)](https://forum.uavcan.org)
+[![Forum](https://img.shields.io/discourse/users.svg?server=https%3A%2F%2Fforum.opencyphal.org&color=1700b3)](https://forum.opencyphal.org)
 
-Libcanard is a compact implementation of the UAVCAN/CAN protocol stack in C99/C11 for high-integrity real-time
+Libcanard is a compact implementation of the Cyphal/CAN protocol stack in C99/C11 for high-integrity real-time
 embedded systems.
 
-[UAVCAN](https://uavcan.org) is an open lightweight data bus standard designed for reliable intravehicular
+[Cyphal](https://opencyphal.org) is an open lightweight data bus standard designed for reliable intravehicular
 communication in aerospace and robotic applications via CAN bus, Ethernet, and other robust transports.
-The acronym UAVCAN stands for *Uncomplicated Application-level Vehicular Computing And Networking*.
 
 **Read the docs in [`libcanard/canard.h`](/libcanard/canard.h).**
 
 Find examples, starters, tutorials on the
-[UAVCAN forum](https://forum.uavcan.org/t/libcanard-examples-starters-tutorials/935).
+[Cyphal forum](https://forum.opencyphal.org/t/libcanard-examples-starters-tutorials/935).
 
 If you want to contribute, please read [`CONTRIBUTING.md`](/CONTRIBUTING.md).
 
 ## Features
 
 - Full test coverage and extensive static analysis.
-- Compliance with automatically enforceable MISRA C rules (reach out to <https://forum.uavcan.org> for details).
+- Compliance with automatically enforceable MISRA C rules (reach out to <https://forum.opencyphal.org> for details).
 - Detailed time complexity and memory requirement models for the benefit of real-time high-integrity applications.
 - Purely reactive API without the need for background servicing.
 - Support for the Classic CAN and CAN FD.
@@ -51,8 +50,8 @@ The platform-specific media IO layer (driver) is supposed to be provided by the 
                       |    Hardware   |
                       +---------------+
 
-The UAVCAN Development Team maintains a collection of various platform-specific components in a separate repository
-at <https://github.com/UAVCAN/platform_specific_components>.
+The OpenCyphal Development Team maintains a collection of various platform-specific components in a separate repository
+at <https://github.com/OpenCyphal/platform_specific_components>.
 Users are encouraged to search through that repository for drivers, examples, and other pieces that may be
 reused in the target application to speed up the design of the media IO layer (driver) for the application.
 
@@ -119,7 +118,7 @@ if (result < 0)
 }
 ```
 
-Use [Nunavut](https://github.com/UAVCAN/nunavut) to automatically generate (de)serialization code from DSDL definitions.
+Use [Nunavut](https://github.com/OpenCyphal/nunavut) to automatically generate (de)serialization code from DSDL definitions.
 
 The CAN frames generated from the message transfer are now stored in the `queue`.
 We need to pick them out one by one and have them transmitted.
@@ -219,7 +218,7 @@ CanardFilter register_access_config = canardMakeFilterForService(384, ins.node_i
 // You can also combine the two filter configurations into one (may also accept irrelevant messages).
 // This allows consolidating a large set of configurations to fit the number of hardware filters.
 // For more information on the optimal subset of configurations to consolidate to minimize wasted CPU,
-// see the UAVCAN specification.
+// see the Cyphal specification.
 CanardFilter combined_config =
         canardConsolidateFilters(&heartbeat_config, &register_access_config);
 configureHardwareFilters(combined_config.extended_can_id, combined_config.extended_mask);
@@ -239,20 +238,20 @@ If you find the examples to be unclear or incorrect, please, open a ticket.
   ([Cavl](https://github.com/pavel-kirienko/cavl) library is distributed with libcanard).
   Traversing the list of RX subscriptions now requires recursive traversal of the tree.
 
-- Manual DSDL serialization helpers removed; use [Nunavut](https://github.com/UAVCAN/nunavut) instead.
+- Manual DSDL serialization helpers removed; use [Nunavut](https://github.com/OpenCyphal/nunavut) instead.
 
 - Replace bitwise CRC computation with much faster static table by default
-  ([#185](https://github.com/UAVCAN/libcanard/issues/185)).
+  ([#185](https://github.com/OpenCyphal/libcanard/issues/185)).
   This can be disabled by setting `CANARD_CRC_TABLE=0`, which is expected to save ca. 500 bytes of ROM.
 
-- Fixed issues with const-correctness in the API ([#175](https://github.com/UAVCAN/libcanard/issues/175)).
+- Fixed issues with const-correctness in the API ([#175](https://github.com/OpenCyphal/libcanard/issues/175)).
 
 - `canardRxAccept2()` renamed to `canardRxAccept()`.
 
 - Support build configuration headers via `CANARD_CONFIG_HEADER`.
 
 - Add API for generating CAN hardware acceptance filter configurations
-  ([#169](https://github.com/UAVCAN/libcanard/issues/169)).
+  ([#169](https://github.com/OpenCyphal/libcanard/issues/169)).
 
 ### v1.1
 

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -1,6 +1,6 @@
 /// This software is distributed under the terms of the MIT License.
-/// Copyright (c) 2016 UAVCAN Consortium.
-/// Author: Pavel Kirienko <pavel@uavcan.org>
+/// Copyright (c) 2016 Cyphal Consortium.
+/// Author: Pavel Kirienko <pavel@opencyphal.org>
 
 #include "canard.h"
 #include "cavl.h"
@@ -577,7 +577,7 @@ typedef struct
     const void*        payload;
 } RxFrameModel;
 
-/// Returns truth if the frame is valid and parsed successfully. False if the frame is not a valid UAVCAN/CAN frame.
+/// Returns truth if the frame is valid and parsed successfully. False if the frame is not a valid Cyphal/CAN frame.
 CANARD_PRIVATE bool rxTryParseFrame(const CanardMicrosecond  timestamp_usec,
                                     const CanardFrame* const frame,
                                     RxFrameModel* const      out)
@@ -800,9 +800,9 @@ CANARD_PRIVATE int8_t rxSessionAcceptFrame(CanardInstance* const          ins,
     return out;
 }
 
-/// RX session state machine update is the most intricate part of any UAVCAN transport implementation.
-/// The state model used here is derived from the reference pseudocode given in the original UAVCAN v0 specification.
-/// The UAVCAN/CAN v1 specification, which this library is an implementation of, does not provide any reference
+/// RX session state machine update is the most intricate part of any Cyphal transport implementation.
+/// The state model used here is derived from the reference pseudocode given in the original Cyphal v0 specification.
+/// The Cyphal/CAN v1 specification, which this library is an implementation of, does not provide any reference
 /// pseudocode. Instead, it takes a higher-level, more abstract approach, where only the high-level requirements
 /// are given and the particular algorithms are left to be implementation-defined. Such abstract approach is much
 /// advantageous because it allows implementers to choose whatever solution works best for the specific application at
@@ -1121,7 +1121,7 @@ int8_t canardRxAccept(CanardInstance* const        ins,
         }
         else
         {
-            out = 0;  // A non-UAVCAN/CAN input frame.
+            out = 0;  // A non-Cyphal/CAN input frame.
         }
     }
     CANARD_ASSERT(out <= 1);

--- a/libcanard/canard.h
+++ b/libcanard/canard.h
@@ -6,7 +6,7 @@
 ///                            |      |            |         |      |         |
 ///                        ----o------o------------o---------o------o---------o-------
 ///
-/// Libcanard is a compact implementation of the UAVCAN/CAN protocol for high-integrity real-time embedded systems.
+/// Libcanard is a compact implementation of the Cyphal/CAN protocol for high-integrity real-time embedded systems.
 /// It is designed for use in robust deterministic embedded systems equipped with at least 32K ROM and 8K RAM.
 /// The codebase follows the MISRA C rules, has 100% test coverage, and is validated by at least two static analyzers.
 /// The library is designed to be compatible with any target platform and instruction set architecture, from 8 to 64
@@ -23,16 +23,16 @@
 /// it is recommended to use O1Heap (MIT licensed): https://github.com/pavel-kirienko/o1heap.
 ///
 /// There are no specific requirements to the underlying I/O layer. Some low-level drivers maintained by the
-/// UAVCAN Consortium may be found at https://github.com/UAVCAN/platform_specific_components.
+/// Cyphal Consortium may be found at https://github.com/OpenCyphal/platform_specific_components.
 ///
 /// If your application requires a MISRA C compliance report, please get in touch with the maintainers via the forum
-/// at https://forum.uavcan.org.
+/// at https://forum.opencyphal.org.
 ///
 ///          ARCHITECTURE
 ///
-/// UAVCAN, as a protocol stack, is composed of two layers: TRANSPORT and PRESENTATION. The transport layer is portable
-/// across different transport protocols, one of which is CAN (FD), formally referred to as UAVCAN/CAN. This library
-/// is focused on UAVCAN/CAN only and it will not support other transports. The presentation layer is implemented
+/// Cyphal, as a protocol stack, is composed of two layers: TRANSPORT and PRESENTATION. The transport layer is portable
+/// across different transport protocols, one of which is CAN (FD), formally referred to as Cyphal/CAN. This library
+/// is focused on Cyphal/CAN only and it will not support other transports. The presentation layer is implemented
 /// through the DSDL language and the associated data type regulation policies; these parts are out of the scope of
 /// this library as it is focused purely on the transport.
 ///
@@ -63,7 +63,7 @@
 /// received (by default, all transfers are ignored); also, the subscription function specifies vital transfer
 /// reassembly parameters such as the maximum payload size (i.e., the maximum size of a serialized representation
 /// of a DSDL object) and the transfer-ID timeout. Transfers that carry more payload than the configured maximum per
-/// subscription are truncated following the Implicit Truncation Rule (ITR) defined by the UAVCAN Specification --
+/// subscription are truncated following the Implicit Truncation Rule (ITR) defined by the Cyphal Specification --
 /// the rule is implemented to facilitate backward-compatible DSDL data type extensibility.
 ///
 /// The library supports a practically unlimited number of redundant transports.
@@ -77,9 +77,9 @@
 /// --------------------------------------------------------------------------------------------------------------------
 ///
 /// This software is distributed under the terms of the MIT License.
-/// Copyright (c) 2016 UAVCAN Consortium.
-/// Author: Pavel Kirienko <pavel@uavcan.org>
-/// Contributors: https://github.com/UAVCAN/libcanard/contributors.
+/// Copyright (c) 2016 Cyphal Consortium.
+/// Author: Pavel Kirienko <pavel@opencyphal.org>
+/// Contributors: https://github.com/OpenCyphal/libcanard/contributors.
 
 #ifndef CANARD_H_INCLUDED
 #define CANARD_H_INCLUDED
@@ -92,14 +92,14 @@
 extern "C" {
 #endif
 
-/// Semantic version of this library (not the UAVCAN specification).
+/// Semantic version of this library (not the Cyphal specification).
 /// API will be backward compatible within the same major version.
 #define CANARD_VERSION_MAJOR 2
 #define CANARD_VERSION_MINOR 0
 
-/// The version number of the UAVCAN specification implemented by this library.
-#define CANARD_UAVCAN_SPECIFICATION_VERSION_MAJOR 1
-#define CANARD_UAVCAN_SPECIFICATION_VERSION_MINOR 0
+/// The version number of the Cyphal specification implemented by this library.
+#define CANARD_CYPHAL_SPECIFICATION_VERSION_MAJOR 1
+#define CANARD_CYPHAL_SPECIFICATION_VERSION_MINOR 0
 
 /// These error codes may be returned from the library API calls whose return type is a signed integer in the negated
 /// form (e.g., error code 2 returned as -2). A non-negative return value represents success.
@@ -111,12 +111,12 @@ extern "C" {
 #define CANARD_ERROR_OUT_OF_MEMORY 3
 
 /// MTU values for the supported protocols.
-/// Per the recommendations given in the UAVCAN/CAN Specification, other MTU values should not be used.
+/// Per the recommendations given in the Cyphal/CAN Specification, other MTU values should not be used.
 #define CANARD_MTU_CAN_CLASSIC 8U
 #define CANARD_MTU_CAN_FD 64U
 #define CANARD_MTU_MAX CANARD_MTU_CAN_FD
 
-/// Parameter ranges are inclusive; the lower bound is zero for all. See UAVCAN/CAN Specification for background.
+/// Parameter ranges are inclusive; the lower bound is zero for all. See Cyphal/CAN Specification for background.
 #define CANARD_SUBJECT_ID_MAX 8191U
 #define CANARD_SERVICE_ID_MAX 511U
 #define CANARD_NODE_ID_MAX 127U
@@ -128,7 +128,7 @@ extern "C" {
 /// Library functions treat all values above CANARD_NODE_ID_MAX as anonymous.
 #define CANARD_NODE_ID_UNSET 255U
 
-/// This is the recommended transfer-ID timeout value given in the UAVCAN Specification. The application may choose
+/// This is the recommended transfer-ID timeout value given in the Cyphal Specification. The application may choose
 /// different values per subscription (i.e., per data specifier) depending on its timing requirements.
 #define CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC 2000000UL
 
@@ -141,7 +141,7 @@ typedef uint16_t                 CanardPortID;
 typedef uint8_t                  CanardNodeID;
 typedef uint8_t                  CanardTransferID;
 
-/// Transfer priority level mnemonics per the recommendations given in the UAVCAN Specification.
+/// Transfer priority level mnemonics per the recommendations given in the Cyphal Specification.
 typedef enum
 {
     CanardPriorityExceptional = 0,
@@ -154,7 +154,7 @@ typedef enum
     CanardPriorityOptional    = 7,
 } CanardPriority;
 
-/// Transfer kinds as defined by the UAVCAN Specification.
+/// Transfer kinds as defined by the Cyphal Specification.
 typedef enum
 {
     CanardTransferKindMessage  = 0,  ///< Multicast, from publisher to all subscribers.
@@ -173,7 +173,7 @@ struct CanardTreeNode
 };
 
 /// CAN data frame with an extended 29-bit ID. RTR/Error frames are not used and therefore not modeled here.
-/// CAN frames with 11-bit ID are not used by UAVCAN/CAN and so they are not supported by the library.
+/// CAN frames with 11-bit ID are not used by Cyphal/CAN and so they are not supported by the library.
 typedef struct
 {
     /// 29-bit extended ID. The bits above 29-th shall be zero.
@@ -196,7 +196,7 @@ extern const uint8_t CanardCANDLCToLength[16];
 /// Conversion look-up table from data length to CAN DLC; the length is rounded up.
 extern const uint8_t CanardCANLengthToDLC[65];
 
-/// A UAVCAN transfer metadata (everything except the payload).
+/// A Cyphal transfer metadata (everything except the payload).
 /// Per Specification, a transfer is represented on the wire as a non-empty set of transport frames (i.e., CAN frames).
 /// The library is responsible for serializing transfers into transport frames when transmitting, and reassembling
 /// transfers from an incoming stream of frames (possibly duplicated if redundant interfaces are used) during reception.
@@ -365,7 +365,7 @@ struct CanardInstance
     void* user_reference;
 
     /// The node-ID of the local node.
-    /// Per the UAVCAN Specification, the node-ID should not be assigned more than once.
+    /// Per the Cyphal Specification, the node-ID should not be assigned more than once.
     /// Invalid values are treated as CANARD_NODE_ID_UNSET. The default value is CANARD_NODE_ID_UNSET.
     CanardNodeID node_id;
 
@@ -508,7 +508,7 @@ CanardTxQueueItem* canardTxPop(CanardTxQueue* const que, const CanardTxQueueItem
 /// This function implements the transfer reassembly logic. It accepts a transport frame from any of the redundant
 /// interfaces, locates the appropriate subscription state, and, if found, updates it. If the frame completed a
 /// transfer, the return value is 1 (one) and the out_transfer pointer is populated with the parameters of the
-/// newly reassembled transfer. The transfer reassembly logic is defined in the UAVCAN specification.
+/// newly reassembled transfer. The transfer reassembly logic is defined in the Cyphal specification.
 ///
 /// The MTU of the accepted frame can be arbitrary; that is, any MTU is accepted. The DLC validity is irrelevant.
 ///
@@ -587,8 +587,8 @@ CanardTxQueueItem* canardTxPop(CanardTxQueue* const que, const CanardTxQueueItem
 ///
 /// The function returns zero if any of the following conditions are true (the general policy is that protocol
 /// errors are not escalated because they do not construe a node-local error):
-///     - The received frame is not a valid UAVCAN/CAN transport frame.
-///     - The received frame is a valid UAVCAN/CAN transport frame, but there is no matching subscription,
+///     - The received frame is not a valid Cyphal/CAN transport frame.
+///     - The received frame is a valid Cyphal/CAN transport frame, but there is no matching subscription,
 ///       the frame did not complete a transfer, the frame forms an invalid frame sequence, the frame is a duplicate,
 ///       the frame is unicast to a different node (address mismatch).
 int8_t canardRxAccept(CanardInstance* const        ins,
@@ -656,7 +656,7 @@ int8_t canardRxUnsubscribe(CanardInstance* const    ins,
 /// Complex applications will likely subscribe to more subject IDs than there are
 /// acceptance filters available in the CAN hardware. In this case, the application
 /// should implement filter consolidation. See canardConsolidateFilters()
-/// as well as the UAVCAN specification for details.
+/// as well as the Cyphal specification for details.
 
 /// Generate an acceptance filter configuration to accept a specific subject ID.
 CanardFilter canardMakeFilterForSubject(const CanardPortID subject_id);
@@ -690,8 +690,8 @@ CanardFilter canardMakeFilterForServices(const CanardNodeID local_node_id);
 /// the set of transfers needed by the application, and the expected frequency of occurrence
 /// of all possible distinct transfers on the bus, it is possible to generate a quasi-optimal configuration
 /// if information about the frequency of occurrence of different transfers is not known.
-/// For details, see the "Automatic hardware acceptance filter configuration" note under the UAVCAN/CAN section
-/// in the Transport Layer chapter of the UAVCAN specification.
+/// For details, see the "Automatic hardware acceptance filter configuration" note under the Cyphal/CAN section
+/// in the Transport Layer chapter of the Cyphal specification.
 CanardFilter canardConsolidateFilters(const CanardFilter* const a, const CanardFilter* const b);
 
 #ifdef __cplusplus

--- a/libcanard/cavl.h
+++ b/libcanard/cavl.h
@@ -6,7 +6,7 @@
 /// See also O1Heap <https://github.com/pavel-kirienko/o1heap> -- a deterministic memory manager for hard-real-time
 /// high-integrity embedded systems.
 ///
-/// Copyright (c) 2021 Pavel Kirienko <pavel@uavcan.org>
+/// Copyright (c) 2021 Pavel Kirienko <pavel@opencyphal.org>
 ///
 /// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 /// documentation files (the "Software"), to deal in the Software without restriction, including without limitation

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # This software is distributed under the terms of the MIT License.
-# Copyright (c) 2016 UAVCAN Consortium.
-# Author: Pavel Kirienko <pavel@uavcan.org>
-# Contributors: https://github.com/UAVCAN/libcanard/contributors.
+# Copyright (c) 2016 Cyphal Consortium.
+# Author: Pavel Kirienko <pavel@opencyphal.org>
+# Contributors: https://github.com/OpenCyphal/libcanard/contributors.
 
 cmake_minimum_required(VERSION 3.12)
 project(canard_tests C CXX)

--- a/tests/catch/main.cpp
+++ b/tests/catch/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 UAVCAN Team
+ * Copyright (c) 2018 OpenCyphal Development Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  *
- * Contributors: https://github.com/UAVCAN/libcanard/contributors
+ * Contributors: https://github.com/OpenCyphal/libcanard/contributors
  */
 
 // For speedy compilation, the file that contains CATCH_CONFIG_MAIN should not contain any actual tests.

--- a/tests/exposed.hpp
+++ b/tests/exposed.hpp
@@ -1,5 +1,5 @@
 // This software is distributed under the terms of the MIT License.
-// Copyright (c) 2016 UAVCAN Development Team.
+// Copyright (c) 2016 Cyphal Development Team.
 
 #pragma once
 

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -1,5 +1,5 @@
 // This software is distributed under the terms of the MIT License.
-// Copyright (c) 2016 UAVCAN Development Team.
+// Copyright (c) 2016 Cyphal Development Team.
 
 #pragma once
 
@@ -19,8 +19,8 @@
 #    error "Library version not defined"
 #endif
 
-#if !(defined(CANARD_UAVCAN_SPECIFICATION_VERSION_MAJOR) && defined(CANARD_UAVCAN_SPECIFICATION_VERSION_MINOR))
-#    error "UAVCAN specification version not defined"
+#if !(defined(CANARD_CYPHAL_SPECIFICATION_VERSION_MAJOR) && defined(CANARD_CYPHAL_SPECIFICATION_VERSION_MINOR))
+#    error "Cyphal specification version not defined"
 #endif
 
 namespace helpers

--- a/tests/test_private_cavl.cpp
+++ b/tests/test_private_cavl.cpp
@@ -1,5 +1,5 @@
 // This software is distributed under the terms of the MIT License.
-// Copyright (c) 2016-2020 UAVCAN Development Team.
+// Copyright (c) 2016-2020 OpenCyphal Development Team.
 // These tests have been adapted from the Cavl test suite that you can find at https://github.com/pavel-kirienko/cavl
 
 #include <cavl.h>

--- a/tests/test_private_crc.cpp
+++ b/tests/test_private_crc.cpp
@@ -1,5 +1,5 @@
 // This software is distributed under the terms of the MIT License.
-// Copyright (c) 2016-2020 UAVCAN Development Team.
+// Copyright (c) 2016-2020 OpenCyphal Development Team.
 
 #include "exposed.hpp"
 #include "catch.hpp"

--- a/tests/test_private_rx.cpp
+++ b/tests/test_private_rx.cpp
@@ -1,5 +1,5 @@
 // This software is distributed under the terms of the MIT License.
-// Copyright (c) 2016-2020 UAVCAN Development Team.
+// Copyright (c) 2016-2020 OpenCyphal Development Team.
 
 #include "exposed.hpp"
 #include "helpers.hpp"

--- a/tests/test_private_tx.cpp
+++ b/tests/test_private_tx.cpp
@@ -1,5 +1,5 @@
 // This software is distributed under the terms of the MIT License.
-// Copyright (c) 2016-2020 UAVCAN Development Team.
+// Copyright (c) 2016-2020 OpenCyphal Development Team.
 
 #include "exposed.hpp"
 #include "helpers.hpp"

--- a/tests/test_public_filters.cpp
+++ b/tests/test_public_filters.cpp
@@ -1,5 +1,5 @@
 // This software is distributed under the terms of the MIT License.
-// Copyright (c) 2016-2021 UAVCAN Development Team.
+// Copyright (c) 2016-2021 OpenCyphal Development Team.
 
 #include "exposed.hpp"
 #include "catch.hpp"

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -1,5 +1,5 @@
 // This software is distributed under the terms of the MIT License.
-// Copyright (c) 2016-2020 UAVCAN Development Team.
+// Copyright (c) 2016-2020 OpenCyphal Development Team.
 
 #include "helpers.hpp"
 #include "exposed.hpp"

--- a/tests/test_public_rx.cpp
+++ b/tests/test_public_rx.cpp
@@ -1,5 +1,5 @@
 // This software is distributed under the terms of the MIT License.
-// Copyright (c) 2016-2020 UAVCAN Development Team.
+// Copyright (c) 2016-2020 OpenCyphal Development Team.
 
 #include "exposed.hpp"
 #include "helpers.hpp"

--- a/tests/test_public_tx.cpp
+++ b/tests/test_public_tx.cpp
@@ -1,5 +1,5 @@
 // This software is distributed under the terms of the MIT License.
-// Copyright (c) 2016 UAVCAN Development Team.
+// Copyright (c) 2016 OpenCyphal Development Team.
 
 #include "exposed.hpp"
 #include "helpers.hpp"

--- a/tests/test_self.cpp
+++ b/tests/test_self.cpp
@@ -1,5 +1,5 @@
 // This software is distributed under the terms of the MIT License.
-// Copyright (c) 2016-2020 UAVCAN Development Team.
+// Copyright (c) 2016-2020 OpenCyphal Development Team.
 
 #include "exposed.hpp"
 #include "helpers.hpp"

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,7 +1,7 @@
 # Development environment for libcanard, based on Ubuntu 20.04 Focal.
 #
 # This software is distributed under the terms of the MIT License.
-# Copyright (c) 2021 UAVCAN Consortium.
+# Copyright (c) 2021-2022 OpenCyphal Development Team.
 # Author: Kalyan Sriram <kalyan@coderkalyan.com>
 
 FROM ubuntu:focal


### PR DESCRIPTION
Mostly automatic renaming. Is Cyphal/CAN correct terminology?