### PR TITLE
Remove SonarCloud cache and threads setup as it is now offered by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,8 +184,6 @@ jobs:
         --define sonar.sources=libcanard
         --define sonar.exclusions=libcanard/cavl.h
         --define sonar.cfamily.gcov.reportsPath=.
-        --define sonar.cfamily.cache.enabled=false
-        --define sonar.cfamily.threads=2
         --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
         --define sonar.host.url="${{ env.SONAR_SERVER_URL }}"
 


### PR DESCRIPTION
No need to configure the cache and threads anymore, SonarCloud now has an automatic analysis caching and threads detection. See https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache.