### PR TITLE
Introduce internal includes section to avoid potential implicit declaration warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ If you find the examples to be unclear or incorrect, please, open a ticket.
 
 - Refactor the transfer reassembly state machine to enhance its maintainability and robustness.
 
+#### v3.1.2
+
+- Allow redefinition of CANARD_ASSERT via the config header;
+  see [#219](https://github.com/OpenCyphal/libcanard/pull/219).
+
 ### v3.0
 
 - Update branding as [UAVCAN v1 is renamed to Cyphal](https://forum.opencyphal.org/t/uavcan-v1-is-now-cyphal/1622).

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -3,7 +3,6 @@
 /// Author: Pavel Kirienko <pavel@opencyphal.org>
 
 #include "canard.h"
-#include "_canard_cavl.h"
 #include <string.h>
 
 // --------------------------------------------- BUILD CONFIGURATION ---------------------------------------------
@@ -37,6 +36,10 @@
 #if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L)
 #    error "Unsupported language: ISO C99 or a newer version is required."
 #endif
+
+// --------------------------------------------- INTERNAL INCLUDES ----------------------------------------------
+
+#include "_canard_cavl.h"
 
 // --------------------------------------------- COMMON DEFINITIONS ---------------------------------------------
 

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -38,6 +38,7 @@
 #endif
 
 // --------------------------------------------- INTERNAL INCLUDES ----------------------------------------------
+// The internal includes are placed here after the config header is included and CANARD_ASSERT is defined.
 
 #include "_canard_cavl.h"
 


### PR DESCRIPTION
During the integration of the `libcanard` into a project based on [ChibiOS](https://www.chibios.org) I want to change `CANARD_ASSERT` from the default `assert` to ChibiOS `osalDbgCheck`. It is done with the next C defines `-DCANARD_ASSERT=osalDbgCheck -DCANARD_CONFIG_HEADER=\"${BINDINGS_DIR}/canard/canard_config.h\"`, there to prevent implicit declaration warnings I unutilized `CANARD_CONFIG_HEADER` by providing a `canard_config.h` file with the following content:
```
#include "osal.h"
```
But because of `#include "_canard_cavl.h"` and `#    include CANARD_CONFIG_HEADER` order in `canard.c` I still get implicit declaration warnings:
```
Compiling canard.c
../../ext/OpenCyphal/libcanard/libcanard/_canard_cavl.h: In function 'cavlPrivateRotate':
<command-line>: warning: implicit declaration of function 'osalDbgCheck' [-Wimplicit-function-declaration]
../../ext/OpenCyphal/libcanard/libcanard/_canard_cavl.h:30:25: note: in expansion of macro 'CANARD_ASSERT'
   30 | #    define CAVL_ASSERT CANARD_ASSERT
      |                         ^~~~~~~~~~~~~
../../ext/OpenCyphal/libcanard/libcanard/_canard_cavl.h:98:5: note: in expansion of macro 'CAVL_ASSERT'
   98 |     CAVL_ASSERT((x != NULL) && (x->lr[!r] != NULL) && ((x->bf >= -1) && (x->bf <= +1)));
      |     ^~~~~~~~~~~
```

To resolve this issue `#    include CANARD_CONFIG_HEADER` must be placed before `#include "_canard_cavl.h"`.