### PR TITLE
Fix for the "Improve RPC Client Response RX pipeline" issue # 228

### DIFF
--- a/libcanard/canard.h
+++ b/libcanard/canard.h
@@ -94,7 +94,7 @@ extern "C" {
 /// Semantic version of this library (not the Cyphal specification).
 /// API will be backward compatible within the same major version.
 #define CANARD_VERSION_MAJOR 3
-#define CANARD_VERSION_MINOR 2
+#define CANARD_VERSION_MINOR 3
 
 /// The version number of the Cyphal specification implemented by this library.
 #define CANARD_CYPHAL_SPECIFICATION_VERSION_MAJOR 1


### PR DESCRIPTION
- added one more case when it's allowed to "restart" transfer reassembly with different transport interface