### PR TITLE
Fixed issue #216 "canardMemFree must provide size"

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ static void* memAllocate(CanardInstance* const canard, const size_t amount)
     return o1heapAllocate(my_allocator, amount);
 }
 
-static void memFree(CanardInstance* const canard, void* const pointer)
+static void memFree(CanardInstance* const canard, void* const pointer, const size_t amount)
 {
     (void) canard;
+    (void) amount;
     o1heapFree(my_allocator, pointer);
 }
 ```

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -984,7 +984,7 @@ CANARD_PRIVATE int8_t rxAcceptFrame(CanardInstance* const       ins,
             out_transfer->timestamp_usec = frame->timestamp_usec;
             out_transfer->payload_size   = payload_size;
             out_transfer->payload        = payload;
-            out_transfer->allocated_size = subscription->extent;
+            out_transfer->allocated_size = payload_size;
             // Clang-Tidy raises an error recommending the use of memcpy_s() instead.
             // We ignore it because the safe functions are poorly supported; reliance on them may limit the portability.
             (void) memcpy(payload, frame->payload, payload_size);  // NOLINT

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -303,8 +303,8 @@ CANARD_PRIVATE TxItem* txAllocateQueueItem(CanardInstance* const   ins,
 {
     CANARD_ASSERT(ins != NULL);
     CANARD_ASSERT(payload_size > 0U);
-    const size_t tx_item_size = (sizeof(TxItem) - CANARD_MTU_MAX) + payload_size;
-    TxItem* const out = (TxItem*) ins->memory_allocate(ins, tx_item_size);
+    const size_t  tx_item_size = (sizeof(TxItem) - CANARD_MTU_MAX) + payload_size;
+    TxItem* const out          = (TxItem*) ins->memory_allocate(ins, tx_item_size);
     if (out != NULL)
     {
         out->base.allocated_size = tx_item_size;

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -790,6 +790,7 @@ CANARD_PRIVATE int8_t rxSessionAcceptFrame(CanardInstance* const          ins,
             out_transfer->timestamp_usec = rxs->transfer_timestamp_usec;
             out_transfer->payload_size   = rxs->payload_size;
             out_transfer->payload        = rxs->payload;
+            out_transfer->allocated_size = (rxs->payload != NULL) ? extent : 0U;
 
             // Cut off the CRC from the payload if it's there -- we don't want to expose it to the user.
             CANARD_ASSERT(rxs->total_payload_size >= rxs->payload_size);
@@ -983,6 +984,7 @@ CANARD_PRIVATE int8_t rxAcceptFrame(CanardInstance* const       ins,
             out_transfer->timestamp_usec = frame->timestamp_usec;
             out_transfer->payload_size   = payload_size;
             out_transfer->payload        = payload;
+            out_transfer->allocated_size = subscription->extent;
             // Clang-Tidy raises an error recommending the use of memcpy_s() instead.
             // We ignore it because the safe functions are poorly supported; reliance on them may limit the portability.
             (void) memcpy(payload, frame->payload, payload_size);  // NOLINT

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -1243,7 +1243,7 @@ int8_t canardRxUnsubscribe(CanardInstance* const    ins,
             {
                 if (sub->sessions[i] != NULL)
                 {
-                    ins->memory_free(ins, sub->sessions[i]->payload, sub->sessions[i]->payload_size);
+                    ins->memory_free(ins, sub->sessions[i]->payload, sub->extent);
                 }
                 ins->memory_free(ins, sub->sessions[i], sizeof(*sub->sessions[i]));
                 sub->sessions[i] = NULL;

--- a/libcanard/canard.h
+++ b/libcanard/canard.h
@@ -285,6 +285,10 @@ struct CanardTxQueueItem
     /// Frames whose transmission deadline is in the past shall be dropped.
     CanardMicrosecond tx_deadline_usec;
 
+    /// Amount of memory allocated for the whole this item, including the payload frame.
+    /// In use to deallocate the item by passing this value to the memory manager (`memFree`).
+    size_t allocated_size;
+
     /// The actual CAN frame data.
     CanardFrame frame;
 };
@@ -349,11 +353,12 @@ typedef struct CanardRxTransfer
 typedef void* (*CanardMemoryAllocate)(CanardInstance* ins, size_t amount);
 
 /// The counterpart of the above -- this function is invoked to return previously allocated memory to the allocator.
-/// The semantics are similar to free():
+/// The semantics are similar to free(), but with additional `amount` parameter:
 ///     - The pointer was previously returned by the allocation function.
 ///     - The pointer may be NULL, in which case the function shall have no effect.
 ///     - The execution time should be constant (O(1)).
-typedef void (*CanardMemoryFree)(CanardInstance* ins, void* pointer);
+///     - The amount is the same as it was during allocation.
+typedef void (*CanardMemoryFree)(CanardInstance* ins, void* pointer, size_t amount);
 
 /// This is the core structure that keeps all of the states and allocated resources of the library instance.
 struct CanardInstance

--- a/libcanard/canard.h
+++ b/libcanard/canard.h
@@ -346,7 +346,8 @@ typedef struct CanardRxTransfer
     void* payload;
 
     /// Size of the allocated payload buffer in bytes.
-    /// Normally equal to the extent specified in the subscription, but may be zero if the payload pointer is NULL.
+    /// Normally equal to the extent specified in the subscription, but could be less (equal to `payload_size`)
+    /// in case of single frame transfer, or even zero if the payload pointer is NULL.
     size_t allocated_size;
 } CanardRxTransfer;
 

--- a/libcanard/canard.h
+++ b/libcanard/canard.h
@@ -336,10 +336,18 @@ typedef struct CanardRxTransfer
     /// The time system may be arbitrary as long as the clock is monotonic (steady).
     CanardMicrosecond timestamp_usec;
 
+    /// Size of the payload data in bytes.
+    /// The value is always less than or equal to the extent specified in the subscription.
     /// If the payload is empty (payload_size = 0), the payload pointer may be NULL.
-    /// The application is required to deallocate the payload buffer after the transfer is processed.
     size_t payload_size;
-    void*  payload;
+
+    /// The application is required to deallocate the payload buffer after the transfer is processed.
+    /// Allocated buffer size (`allocated_size`, not `payload_size`) should be used to deallocate the buffer.
+    void* payload;
+
+    /// Size of the allocated payload buffer in bytes.
+    /// Normally equal to the extent specified in the subscription, but may be zero if the payload pointer is NULL.
+    size_t allocated_size;
 } CanardRxTransfer;
 
 /// A pointer to the memory allocation function. The semantics are similar to malloc():

--- a/tests/exposed.hpp
+++ b/tests/exposed.hpp
@@ -107,7 +107,7 @@ auto rxSessionWritePayload(CanardInstance* const ins,
                            const std::size_t     payload_size,
                            const void* const     payload) -> std::int8_t;
 
-void rxSessionRestart(CanardInstance* const ins, RxSession* const rxs);
+void rxSessionRestart(CanardInstance* const ins, RxSession* const rxs, const std::size_t allocated_size);
 
 auto rxSessionUpdate(CanardInstance* const     ins,
                      RxSession* const          rxs,

--- a/tests/test_private_rx.cpp
+++ b/tests/test_private_rx.cpp
@@ -229,7 +229,7 @@ TEST_CASE("rxSessionWritePayload")
     REQUIRE(rxs.payload[9] == 9);
 
     // Restart frees the buffer. The transfer-ID will be incremented, too.
-    rxSessionRestart(&ins.getInstance(), &rxs);
+    rxSessionRestart(&ins.getInstance(), &rxs, 10);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
     REQUIRE(rxs.payload_size == 0);
@@ -242,7 +242,7 @@ TEST_CASE("rxSessionWritePayload")
     rxs.calculated_crc = 0x1234U;
     rxs.transfer_id    = 23;
     rxs.toggle         = false;
-    rxSessionRestart(&ins.getInstance(), &rxs);
+    rxSessionRestart(&ins.getInstance(), &rxs, 10);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
     REQUIRE(rxs.payload_size == 0);
@@ -255,7 +255,7 @@ TEST_CASE("rxSessionWritePayload")
     rxs.calculated_crc = 0x1234U;
     rxs.transfer_id    = 31;
     rxs.toggle         = false;
-    rxSessionRestart(&ins.getInstance(), &rxs);
+    rxSessionRestart(&ins.getInstance(), &rxs, 10);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
     REQUIRE(rxs.payload_size == 0);
@@ -343,7 +343,7 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x01\x01", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, 16);
 
     // Valid next transfer, wrong transport.
     frame.timestamp_usec = 10'000'100;
@@ -379,7 +379,7 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(0 == std::memcmp(transfer.payload, "\x03\x03\x03", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, 16);
 
     // Same TID.
     frame.timestamp_usec = 10'000'200;
@@ -416,7 +416,7 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(0 == std::memcmp(transfer.payload, "\x05\x05\x05", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, 16);
 
     // Restart due to TID timeout, switch iface.
     frame.timestamp_usec = 20'000'000;
@@ -440,7 +440,7 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(0 == std::memcmp(transfer.payload, "\x05\x05\x05", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, 16);
 
     // Multi-frame, first.
     frame.timestamp_usec  = 20'000'100;
@@ -518,7 +518,7 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(0 == std::memcmp(transfer.payload, "\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07\x09\x09", 16));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, 16);
 
     // TID timeout does not occur until SOT; see https://github.com/OpenCyphal/libcanard/issues/212.
     frame.timestamp_usec    = 30'000'000;
@@ -619,7 +619,7 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(0 == std::memcmp(transfer.payload, "\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0D\x0D\x0D", 10));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, 16);
 
     // CRC SPLIT -- first frame.
     frame.timestamp_usec    = 30'000'000;
@@ -666,7 +666,7 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(0 == std::memcmp(transfer.payload, "\x0E\x0E\x0E\x0E\x0E\x0E\x0E", 7));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, 16);
 
     // BAD CRC -- first frame.
     frame.timestamp_usec    = 30'001'000;

--- a/tests/test_private_rx.cpp
+++ b/tests/test_private_rx.cpp
@@ -340,10 +340,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 11);
     REQUIRE(transfer.payload_size == 3);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x01\x01", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, 16);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // Valid next transfer, wrong transport.
     frame.timestamp_usec = 10'000'100;
@@ -376,10 +377,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 12);
     REQUIRE(transfer.payload_size == 3);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x03\x03\x03", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, 16);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // Same TID.
     frame.timestamp_usec = 10'000'200;
@@ -413,10 +415,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 12);
     REQUIRE(transfer.payload_size == 3);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x05\x05\x05", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, 16);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // Restart due to TID timeout, switch iface.
     frame.timestamp_usec = 20'000'000;
@@ -437,10 +440,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 11);
     REQUIRE(transfer.payload_size == 3);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x05\x05\x05", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, 16);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // Multi-frame, first.
     frame.timestamp_usec  = 20'000'100;
@@ -515,10 +519,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 13);
     REQUIRE(transfer.payload_size == 16);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07\x09\x09", 16));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, 16);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // TID timeout does not occur until SOT; see https://github.com/OpenCyphal/libcanard/issues/212.
     frame.timestamp_usec    = 30'000'000;
@@ -616,10 +621,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 10);
     REQUIRE(transfer.payload_size == 10);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0D\x0D\x0D", 10));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, 16);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // CRC SPLIT -- first frame.
     frame.timestamp_usec    = 30'000'000;
@@ -663,10 +669,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 0);
     REQUIRE(transfer.payload_size == 7);  // ONE CRC BYTE BACKTRACKED!
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x0E\x0E\x0E\x0E\x0E\x0E\x0E", 7));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, 16);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // BAD CRC -- first frame.
     frame.timestamp_usec    = 30'001'000;

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -191,9 +191,10 @@ TEST_CASE("RoundtripSimple")
                     else
                     {
                         REQUIRE(transfer.payload_size == 0U);
+                        REQUIRE(transfer.allocated_size == 0U);
                     }
 
-                    ins_rx.getAllocator().deallocate(transfer.payload, subscription->extent);
+                    ins_rx.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
                     std::free(ref_payload);  // NOLINT
                 }
                 else

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -193,7 +193,7 @@ TEST_CASE("RoundtripSimple")
                         REQUIRE(transfer.payload_size == 0U);
                     }
 
-                    ins_rx.getAllocator().deallocate(transfer.payload);
+                    ins_rx.getAllocator().deallocate(transfer.payload, subscription->extent);
                     std::free(ref_payload);  // NOLINT
                 }
                 else
@@ -212,7 +212,7 @@ TEST_CASE("RoundtripSimple")
 
             {
                 const std::lock_guard locker(lock);
-                ins_tx.getAllocator().deallocate(ti);
+                ins_tx.getAllocator().deallocate(ti, (ti != nullptr) ? ti->allocated_size : 0);
             }
 
             if (std::chrono::steady_clock::now() > deadline)

--- a/tests/test_public_rx.cpp
+++ b/tests/test_public_rx.cpp
@@ -345,8 +345,8 @@ TEST_CASE("RxAnonymous")
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == CANARD_NODE_ID_UNSET);
     REQUIRE(transfer.metadata.transfer_id == 0);
-    REQUIRE(transfer.payload_size == 6);  // NOT truncated.
-    REQUIRE(transfer.allocated_size == 16);
+    REQUIRE(transfer.payload_size == 6);    // NOT truncated.
+    REQUIRE(transfer.allocated_size == 6);  // Less than extent b/c it's anonymous single frame transfer.
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06", 0));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);      // The PAYLOAD BUFFER only! No session for anons.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 6);       // Smaller allocation.

--- a/tests/test_public_rx.cpp
+++ b/tests/test_public_rx.cpp
@@ -188,7 +188,7 @@ TEST_CASE("RxBasic0")
     REQUIRE(nullptr == ins.rxGetSubscription(CanardTransferKindMessage, 0b0110011001100));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 16 + 20));
-    ins.getAllocator().deallocate(msg_payload);
+    ins.getAllocator().deallocate(msg_payload, 16);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 3);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 20));
 
@@ -321,7 +321,7 @@ TEST_CASE("RxAnonymous")
     REQUIRE(ensureAllNullptr(ins.getMessageSubs().at(0)->sessions));  // No RX states!
 
     // Release the memory.
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, subscription->extent);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
 
@@ -440,7 +440,7 @@ TEST_CASE("Issue189")  // https://github.com/OpenCyphal/libcanard/issues/189
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, subscription->extent);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 
@@ -491,7 +491,7 @@ TEST_CASE("Issue189")  // https://github.com/OpenCyphal/libcanard/issues/189
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, subscription->extent);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 }
@@ -565,7 +565,7 @@ TEST_CASE("Issue212")
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, subscription->extent);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 
@@ -599,7 +599,7 @@ TEST_CASE("Issue212")
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, subscription->extent);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 }
@@ -668,7 +668,7 @@ TEST_CASE("RxFixedTIDWithSmallTimeout")
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, subscription->extent);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 
@@ -692,7 +692,7 @@ TEST_CASE("RxFixedTIDWithSmallTimeout")
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, subscription->extent);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 
@@ -713,7 +713,7 @@ TEST_CASE("RxFixedTIDWithSmallTimeout")
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, subscription->extent);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 }

--- a/tests/test_public_tx.cpp
+++ b/tests/test_public_tx.cpp
@@ -129,7 +129,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 8));
     REQUIRE((0b11100000U | 21U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[11]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'000'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    auto* item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(2 == que.getSize());
     REQUIRE(2 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -138,7 +139,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 7));
     REQUIRE((0b10100000U | 22U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[7]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'000'100ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -149,7 +151,8 @@ TEST_CASE("TxBasic0")
     REQUIRE((CRC8 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[2]);
     REQUIRE((0b01000000U | 22U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[3]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'000'100ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -181,7 +184,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 31));
     REQUIRE((0b10100000U | 25U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'001'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(2 == que.getSize());
     REQUIRE(2 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -191,7 +195,8 @@ TEST_CASE("TxBasic0")
     REQUIRE((CRC61 >> 8U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[30]);
     REQUIRE((0b00000000U | 25U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'001'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -200,7 +205,8 @@ TEST_CASE("TxBasic0")
     REQUIRE((CRC61 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[0]);
     REQUIRE((0b01100000U | 25U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[1]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'001'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -223,7 +229,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 31));
     REQUIRE((0b10100000U | 26U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'002'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(2 == que.getSize());
     REQUIRE(2 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -232,7 +239,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data() + 31U, 31));
     REQUIRE((0b00000000U | 26U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'002'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -242,7 +250,8 @@ TEST_CASE("TxBasic0")
     REQUIRE((CRC62 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[1]);
     REQUIRE((0b01100000U | 26U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[2]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'002'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -263,7 +272,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 63));
     REQUIRE((0b10100000U | 27U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[63]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'003'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -277,7 +287,8 @@ TEST_CASE("TxBasic0")
     REQUIRE((CRC112Padding12 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[62]);  // CRC
     REQUIRE((0b01000000U | 27U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[63]);        // Tail
     REQUIRE(ti->tx_deadline_usec == 1'000'000'003'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -297,7 +308,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(ti->frame.payload_size == 1);
     REQUIRE((0b11100000U | 28U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[0]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'004'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -444,7 +456,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 8));
     REQUIRE((0b11100000U | 21U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[11]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'000'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    auto* item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(2 == que.getSize());
     REQUIRE(2 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -453,7 +466,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 7));
     REQUIRE((0b10100000U | 22U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[7]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'000'100ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -464,7 +478,8 @@ TEST_CASE("TxBasic1")
     REQUIRE((CRC8 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[2]);
     REQUIRE((0b01000000U | 22U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[3]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'000'100ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -494,7 +509,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 31));
     REQUIRE((0b10100000U | 25U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'001'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(2 == que.getSize());
     REQUIRE(2 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -504,7 +520,8 @@ TEST_CASE("TxBasic1")
     REQUIRE((CRC61 >> 8U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[30]);
     REQUIRE((0b00000000U | 25U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'001'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -513,7 +530,8 @@ TEST_CASE("TxBasic1")
     REQUIRE((CRC61 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[0]);
     REQUIRE((0b01100000U | 25U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[1]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'001'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -536,7 +554,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 31));
     REQUIRE((0b10100000U | 26U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'002'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(2 == que.getSize());
     REQUIRE(2 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -545,7 +564,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data() + 31U, 31));
     REQUIRE((0b00000000U | 26U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'002'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -555,7 +575,8 @@ TEST_CASE("TxBasic1")
     REQUIRE((CRC62 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[1]);
     REQUIRE((0b01100000U | 26U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[2]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'002'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -576,7 +597,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 63));
     REQUIRE((0b10100000U | 27U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[63]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'003'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -590,7 +612,8 @@ TEST_CASE("TxBasic1")
     REQUIRE((CRC112Padding12 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[62]);  // CRC
     REQUIRE((0b01000000U | 27U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[63]);        // Tail
     REQUIRE(ti->tx_deadline_usec == 1'000'000'003'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -610,7 +633,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(ti->frame.payload_size == 1);
     REQUIRE((0b11100000U | 28U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[0]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'004'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 

--- a/tests/test_self.cpp
+++ b/tests/test_self.cpp
@@ -30,7 +30,7 @@ TEST_CASE("TestAllocator")
     REQUIRE(3 == al.getNumAllocatedFragments());
     REQUIRE(600 == al.getTotalAllocatedAmount());
 
-    al.deallocate(a);
+    al.deallocate(a, 123);
     REQUIRE(2 == al.getNumAllocatedFragments());
     REQUIRE(477 == al.getTotalAllocatedAmount());
 
@@ -38,15 +38,15 @@ TEST_CASE("TestAllocator")
     REQUIRE(3 == al.getNumAllocatedFragments());
     REQUIRE(577 == al.getTotalAllocatedAmount());
 
-    al.deallocate(c);
+    al.deallocate(c, 21);
     REQUIRE(2 == al.getNumAllocatedFragments());
     REQUIRE(556 == al.getTotalAllocatedAmount());
 
-    al.deallocate(d);
+    al.deallocate(d, 100);
     REQUIRE(1 == al.getNumAllocatedFragments());
     REQUIRE(456 == al.getTotalAllocatedAmount());
 
-    al.deallocate(b);
+    al.deallocate(b, 456);
     REQUIRE(0 == al.getNumAllocatedFragments());
     REQUIRE(0 == al.getTotalAllocatedAmount());
 }


### PR DESCRIPTION
- Extended `CanardTxQueueItem` with extra `allocated_size` field to remember original size allocated for the item (and its embedded payload).
- Extended `CanardRxTransfer` with extra `allocated_size` field to report to the client original size allocated for the payload buffer (which is normally equal to session `extent`).