### PR TITLE
`canardTxPeek` now returns mutable item

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh $LLVM_VERSION
           # we don't need firefox but it takes a lot of time to upgrade
-          snap disable firefox && snap remove --purge firefox
+          sudo snap disable firefox && sudo snap remove --purge firefox
           sudo apt update -y && sudo apt upgrade -y
           sudo apt-get -y install gcc-multilib g++-multilib clang-tidy-$LLVM_VERSION
           sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-$LLVM_VERSION 50
@@ -63,8 +63,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
+          # Upgrading and installing dependencies.
           # we don't need firefox but it takes a lot of time to upgrade
-          snap disable firefox && snap remove --purge firefox
+          sudo snap disable firefox && sudo snap remove --purge firefox
           sudo apt update -y && sudo apt upgrade -y
           sudo apt install gcc-multilib g++-multilib
       - run: >
@@ -95,8 +96,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
+          # Upgrading and installing dependencies.
           # we don't need firefox but it takes a lot of time to upgrade
-          snap disable firefox && snap remove --purge firefox
+          sudo snap disable firefox && sudo snap remove --purge firefox
           sudo apt update -y && sudo apt upgrade -y
           sudo apt install gcc-avr avr-libc
           avr-gcc --version
@@ -113,8 +115,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
+          # Upgrading and installing dependencies.
           # we don't need firefox but it takes a lot of time to upgrade
-          snap disable firefox && snap remove --purge firefox
+          sudo snap disable firefox && sudo snap remove --purge firefox
           sudo apt update -y && sudo apt upgrade -y
           sudo apt-get install -y gcc-arm-none-eabi
       - run: arm-none-eabi-gcc libcanard/*.c -c -std=c99 ${{ env.flags }}
@@ -152,8 +155,9 @@ jobs:
 
     - name: Install Dependencies
       run: |
+        # Upgrading and installing dependencies.
         # we don't need firefox but it takes a lot of time to upgrade
-        snap disable firefox && snap remove --purge firefox
+        sudo snap disable firefox && sudo snap remove --purge firefox
         sudo apt update -y && sudo apt upgrade -y
         sudo apt install -y gcc-multilib g++-multilib
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,6 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh $LLVM_VERSION
-          # we don't need firefox but it takes a lot of time to upgrade
-          sudo snap disable firefox && sudo snap remove --purge firefox
           sudo apt update -y && sudo apt upgrade -y
           sudo apt-get -y install gcc-multilib g++-multilib clang-tidy-$LLVM_VERSION
           sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-$LLVM_VERSION 50
@@ -63,9 +61,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          # Upgrading and installing dependencies.
-          # we don't need firefox but it takes a lot of time to upgrade
-          sudo snap disable firefox && sudo snap remove --purge firefox
           sudo apt update -y && sudo apt upgrade -y
           sudo apt install gcc-multilib g++-multilib
       - run: >
@@ -96,9 +91,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          # Upgrading and installing dependencies.
-          # we don't need firefox but it takes a lot of time to upgrade
-          sudo snap disable firefox && sudo snap remove --purge firefox
           sudo apt update -y && sudo apt upgrade -y
           sudo apt install gcc-avr avr-libc
           avr-gcc --version
@@ -115,9 +107,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          # Upgrading and installing dependencies.
-          # we don't need firefox but it takes a lot of time to upgrade
-          sudo snap disable firefox && sudo snap remove --purge firefox
           sudo apt update -y && sudo apt upgrade -y
           sudo apt-get install -y gcc-arm-none-eabi
       - run: arm-none-eabi-gcc libcanard/*.c -c -std=c99 ${{ env.flags }}
@@ -155,9 +144,6 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        # Upgrading and installing dependencies.
-        # we don't need firefox but it takes a lot of time to upgrade
-        sudo snap disable firefox && sudo snap remove --purge firefox
         sudo apt update -y && sudo apt upgrade -y
         sudo apt install -y gcc-multilib g++-multilib
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh $LLVM_VERSION
+          # we don't need firefox but it takes a lot of time to upgrade
+          snap disable firefox && snap remove --purge firefox
           sudo apt update -y && sudo apt upgrade -y
           sudo apt-get -y install gcc-multilib g++-multilib clang-tidy-$LLVM_VERSION
           sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-$LLVM_VERSION 50
@@ -61,6 +63,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
+          # we don't need firefox but it takes a lot of time to upgrade
+          snap disable firefox && snap remove --purge firefox
           sudo apt update -y && sudo apt upgrade -y
           sudo apt install gcc-multilib g++-multilib
       - run: >
@@ -91,6 +95,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
+          # we don't need firefox but it takes a lot of time to upgrade
+          snap disable firefox && snap remove --purge firefox
           sudo apt update -y && sudo apt upgrade -y
           sudo apt install gcc-avr avr-libc
           avr-gcc --version
@@ -107,6 +113,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
+          # we don't need firefox but it takes a lot of time to upgrade
+          snap disable firefox && snap remove --purge firefox
           sudo apt update -y && sudo apt upgrade -y
           sudo apt-get install -y gcc-arm-none-eabi
       - run: arm-none-eabi-gcc libcanard/*.c -c -std=c99 ${{ env.flags }}
@@ -144,6 +152,8 @@ jobs:
 
     - name: Install Dependencies
       run: |
+        # we don't need firefox but it takes a lot of time to upgrade
+        snap disable firefox && snap remove --purge firefox
         sudo apt update -y && sudo apt upgrade -y
         sudo apt install -y gcc-multilib g++-multilib
 

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -1102,14 +1102,14 @@ int32_t canardTxPush(CanardTxQueue* const                que,
     return out;
 }
 
-const CanardTxQueueItem* canardTxPeek(const CanardTxQueue* const que)
+CanardTxQueueItem* canardTxPeek(const CanardTxQueue* const que)
 {
-    const CanardTxQueueItem* out = NULL;
+    CanardTxQueueItem* out = NULL;
     if (que != NULL)
     {
         // Paragraph 6.7.2.1.15 of the C standard says:
         //     A pointer to a structure object, suitably converted, points to its initial member, and vice versa.
-        out = (const CanardTxQueueItem*) (void*) cavlFindExtremum(que->root, false);
+        out = (CanardTxQueueItem*) (void*) cavlFindExtremum(que->root, false);
     }
     return out;
 }

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -147,23 +147,12 @@ CANARD_PRIVATE TransferCRC crcAdd(const TransferCRC crc, const struct CanardPayl
 
 // --------------------------------------------- TRANSMISSION ---------------------------------------------
 
-/// This is a subclass of CanardTxQueueItem. A pointer to this type can be cast to CanardTxQueueItem safely.
-/// This is standard-compliant. The paragraph 6.7.2.1.15 says:
-///     A pointer to a structure object, suitably converted, points to its initial member (or if that member is a
-///     bit-field, then to the unit in which it resides), and vice versa. There may be unnamed padding within a
-///     structure object, but not at its beginning.
-typedef struct TxItem
-{
-    CanardTxQueueItem base;
-    uint8_t           payload_buffer[CANARD_MTU_MAX];
-} TxItem;
-
 /// Chain of TX frames prepared for insertion into a TX queue.
 typedef struct
 {
-    TxItem* head;
-    TxItem* tail;
-    size_t  size;
+    CanardTxQueueItem* head;
+    CanardTxQueueItem* tail;
+    size_t             size;
 } TxChain;
 
 CANARD_PRIVATE uint32_t txMakeMessageSessionSpecifier(const CanardPortID subject_id, const CanardNodeID src_node_id)
@@ -295,30 +284,42 @@ CANARD_PRIVATE size_t txRoundFramePayloadSizeUp(const size_t x)
 }
 
 /// The item is only allocated and initialized, but NOT included into the queue! The caller needs to do that.
-CANARD_PRIVATE TxItem* txAllocateQueueItem(CanardTxQueue* const    que,
-                                           const uint32_t          id,
-                                           const CanardMicrosecond deadline_usec,
-                                           const size_t            payload_size)
+CANARD_PRIVATE CanardTxQueueItem* txAllocateQueueItem(CanardTxQueue* const        que,
+                                                      const CanardInstance* const ins,
+                                                      const uint32_t              id,
+                                                      const CanardMicrosecond     deadline_usec,
+                                                      const size_t                payload_size)
 {
     CANARD_ASSERT(que != NULL);
     CANARD_ASSERT(payload_size > 0U);
-    const size_t  tx_item_size = (sizeof(TxItem) - CANARD_MTU_MAX) + payload_size;
-    TxItem* const out          = (TxItem*) que->memory.allocate(que->memory.user_reference, tx_item_size);
+
+    // TX queue items are allocated in the memory pool of the instance.
+    // These items are just TX pipeline support structures, they are not directly transfer payload data.
+    // In contrast, see below allocation of the payload buffer from a different memory pool.
+    CanardTxQueueItem* const out = ins->memory.allocate(ins->memory.user_reference, sizeof(CanardTxQueueItem));
     if (out != NULL)
     {
-        out->base.allocated_size = tx_item_size;
+        out->base.up    = NULL;
+        out->base.lr[0] = NULL;
+        out->base.lr[1] = NULL;
+        out->base.bf    = 0;
 
-        out->base.base.up    = NULL;
-        out->base.base.lr[0] = NULL;
-        out->base.base.lr[1] = NULL;
-        out->base.base.bf    = 0;
+        out->next_in_transfer = NULL;  // Last by default.
+        out->tx_deadline_usec = deadline_usec;
 
-        out->base.next_in_transfer = NULL;  // Last by default.
-        out->base.tx_deadline_usec = deadline_usec;
+        // The payload is allocated in the memory pool of the TX queue.
+        // The memory pool of the queue is supposed to be provided by the media.
+        void* const payload_data = que->memory.allocate(que->memory.user_reference, payload_size);
+        if (payload_data == NULL)
+        {
+            ins->memory.deallocate(ins->memory.user_reference, sizeof(CanardTxQueueItem), out);
+            return NULL;
+        }
 
-        out->base.frame.payload.size    = payload_size;
-        out->base.frame.payload.data    = out->payload_buffer;
-        out->base.frame.extended_can_id = id;
+        out->frame.payload.size           = payload_size;
+        out->frame.payload.data           = payload_data;
+        out->frame.payload.allocated_size = payload_size;
+        out->frame.extended_can_id        = id;
     }
     return out;
 }
@@ -336,21 +337,22 @@ CANARD_PRIVATE int8_t txAVLPredicate(void* const user_reference,  // NOSONAR Cav
 }
 
 /// Returns the number of frames enqueued or error (i.e., =1 or <0).
-CANARD_PRIVATE int32_t txPushSingleFrame(CanardTxQueue* const       que,
-                                         const CanardMicrosecond    deadline_usec,
-                                         const uint32_t             can_id,
-                                         const CanardTransferID     transfer_id,
-                                         const struct CanardPayload payload)
+CANARD_PRIVATE int32_t txPushSingleFrame(CanardTxQueue* const        que,
+                                         const CanardInstance* const ins,
+                                         const CanardMicrosecond     deadline_usec,
+                                         const uint32_t              can_id,
+                                         const CanardTransferID      transfer_id,
+                                         const struct CanardPayload  payload)
 {
-    CANARD_ASSERT(que != NULL);
+    CANARD_ASSERT((que != NULL) && (ins != NULL));
     CANARD_ASSERT((payload.data != NULL) || (payload.size == 0));
     const size_t frame_payload_size = txRoundFramePayloadSizeUp(payload.size + 1U);
     CANARD_ASSERT(frame_payload_size > payload.size);
     const size_t padding_size = frame_payload_size - payload.size - 1U;
     CANARD_ASSERT((padding_size + payload.size + 1U) == frame_payload_size);
-    int32_t       out = 0;
-    TxItem* const tqi =
-        (que->size < que->capacity) ? txAllocateQueueItem(que, can_id, deadline_usec, frame_payload_size) : NULL;
+    int32_t                  out = 0;
+    CanardTxQueueItem* const tqi =
+        (que->size < que->capacity) ? txAllocateQueueItem(que, ins, can_id, deadline_usec, frame_payload_size) : NULL;
     if (tqi != NULL)
     {
         if (payload.size > 0U)  // The check is needed to avoid calling memcpy() with a NULL pointer, it's an UB.
@@ -358,16 +360,17 @@ CANARD_PRIVATE int32_t txPushSingleFrame(CanardTxQueue* const       que,
             CANARD_ASSERT(payload.data != NULL);
             // Clang-Tidy raises an error recommending the use of memcpy_s() instead.
             // We ignore it because the safe functions are poorly supported; reliance on them may limit the portability.
-            (void) memcpy(&tqi->payload_buffer[0], payload.data, payload.size);  // NOLINT
+            (void) memcpy(tqi->frame.payload.data, payload.data, payload.size);  // NOLINT
         }
         // Clang-Tidy raises an error recommending the use of memset_s() instead.
         // We ignore it because the safe functions are poorly supported; reliance on them may limit the portability.
-        (void) memset(&tqi->payload_buffer[payload.size], PADDING_BYTE_VALUE, padding_size);  // NOLINT
-        tqi->payload_buffer[frame_payload_size - 1U] = txMakeTailByte(true, true, true, transfer_id);
+        uint8_t* const frame_bytes = tqi->frame.payload.data;
+        (void) memset(frame_bytes + payload.size, PADDING_BYTE_VALUE, padding_size);  // NOLINT
+        *(frame_bytes + frame_payload_size - 1U) = txMakeTailByte(true, true, true, transfer_id);
         // Insert the newly created TX item into the queue.
-        const CanardTreeNode* const res = cavlSearch(&que->root, &tqi->base.base, &txAVLPredicate, &avlTrivialFactory);
+        const CanardTreeNode* const res = cavlSearch(&que->root, &tqi->base, &txAVLPredicate, &avlTrivialFactory);
         (void) res;
-        CANARD_ASSERT(res == &tqi->base.base);
+        CANARD_ASSERT(res == &tqi->base);
         que->size++;
         CANARD_ASSERT(que->size <= que->capacity);
         out = 1;  // One frame enqueued.
@@ -381,19 +384,20 @@ CANARD_PRIVATE int32_t txPushSingleFrame(CanardTxQueue* const       que,
 }
 
 /// Produces a chain of Tx queue items for later insertion into the Tx queue. The tail is NULL if OOM.
-CANARD_PRIVATE TxChain txGenerateMultiFrameChain(CanardTxQueue* const       que,
-                                                 const size_t               presentation_layer_mtu,
-                                                 const CanardMicrosecond    deadline_usec,
-                                                 const uint32_t             can_id,
-                                                 const CanardTransferID     transfer_id,
-                                                 const struct CanardPayload payload)
+CANARD_PRIVATE TxChain txGenerateMultiFrameChain(CanardTxQueue* const        que,
+                                                 const CanardInstance* const ins,
+                                                 const size_t                presentation_layer_mtu,
+                                                 const CanardMicrosecond     deadline_usec,
+                                                 const uint32_t              can_id,
+                                                 const CanardTransferID      transfer_id,
+                                                 const struct CanardPayload  payload)
 {
     CANARD_ASSERT(que != NULL);
     CANARD_ASSERT(presentation_layer_mtu > 0U);
     CANARD_ASSERT(payload.size > presentation_layer_mtu);  // Otherwise, a single-frame transfer should be used.
     CANARD_ASSERT(payload.data != NULL);
 
-    TxChain        out                   = {NULL, NULL, 0};
+    TxChain        out                   = {.head = NULL, .tail = NULL, .size = 0U};
     const size_t   payload_size_with_crc = payload.size + CRC_SIZE_BYTES;
     size_t         offset                = 0U;
     TransferCRC    crc                   = crcAdd(CRC_INITIAL, payload);
@@ -406,7 +410,8 @@ CANARD_PRIVATE TxChain txGenerateMultiFrameChain(CanardTxQueue* const       que,
             ((payload_size_with_crc - offset) < presentation_layer_mtu)
                 ? txRoundFramePayloadSizeUp((payload_size_with_crc - offset) + 1U)  // Padding in the last frame only.
                 : (presentation_layer_mtu + 1U);
-        TxItem* const tqi = txAllocateQueueItem(que, can_id, deadline_usec, frame_payload_size_with_tail);
+        CanardTxQueueItem* const tqi =
+            txAllocateQueueItem(que, ins, can_id, deadline_usec, frame_payload_size_with_tail);
         if (NULL == out.head)
         {
             out.head = tqi;
@@ -415,7 +420,7 @@ CANARD_PRIVATE TxChain txGenerateMultiFrameChain(CanardTxQueue* const       que,
         {
             // C std, 6.7.2.1.15: A pointer to a structure object <...> points to its initial member, and vice versa.
             // Can't just read tqi->base because tqi may be NULL; https://github.com/OpenCyphal/libcanard/issues/203.
-            out.tail->base.next_in_transfer = (CanardTxQueueItem*) tqi;
+            out.tail->next_in_transfer = tqi;
         }
         out.tail = tqi;
         if (NULL == out.tail)
@@ -424,8 +429,9 @@ CANARD_PRIVATE TxChain txGenerateMultiFrameChain(CanardTxQueue* const       que,
         }
 
         // Copy the payload into the frame.
-        const size_t frame_payload_size = frame_payload_size_with_tail - 1U;
-        size_t       frame_offset       = 0U;
+        uint8_t* const frame_bytes        = tqi->frame.payload.data;
+        const size_t   frame_payload_size = frame_payload_size_with_tail - 1U;
+        size_t         frame_offset       = 0U;
         if (offset < payload.size)
         {
             size_t move_size = payload.size - offset;
@@ -436,7 +442,7 @@ CANARD_PRIVATE TxChain txGenerateMultiFrameChain(CanardTxQueue* const       que,
             // Clang-Tidy raises an error recommending the use of memcpy_s() instead.
             // We ignore it because the safe functions are poorly supported; reliance on them may limit the portability.
             // SonarQube incorrectly detects a buffer overflow here.
-            (void) memcpy(&out.tail->payload_buffer[0], payload_ptr, move_size);  // NOLINT NOSONAR
+            (void) memcpy(frame_bytes, payload_ptr, move_size);  // NOLINT NOSONAR
             frame_offset = frame_offset + move_size;
             offset += move_size;
             payload_ptr += move_size;
@@ -448,7 +454,7 @@ CANARD_PRIVATE TxChain txGenerateMultiFrameChain(CanardTxQueue* const       que,
             // Insert padding -- only in the last frame. Don't forget to include padding into the CRC.
             while ((frame_offset + CRC_SIZE_BYTES) < frame_payload_size)
             {
-                out.tail->payload_buffer[frame_offset] = PADDING_BYTE_VALUE;
+                frame_bytes[frame_offset] = PADDING_BYTE_VALUE;
                 ++frame_offset;
                 crc = crcAddByte(crc, PADDING_BYTE_VALUE);
             }
@@ -457,22 +463,22 @@ CANARD_PRIVATE TxChain txGenerateMultiFrameChain(CanardTxQueue* const       que,
             if ((frame_offset < frame_payload_size) && (offset == payload.size))
             {
                 // SonarQube incorrectly detects a buffer overflow here.
-                out.tail->payload_buffer[frame_offset] = (uint8_t) (crc >> BITS_PER_BYTE);  // NOSONAR
+                frame_bytes[frame_offset] = (uint8_t) (crc >> BITS_PER_BYTE);  // NOSONAR
                 ++frame_offset;
                 ++offset;
             }
             if ((frame_offset < frame_payload_size) && (offset > payload.size))
             {
-                out.tail->payload_buffer[frame_offset] = (uint8_t) (crc & BYTE_MAX);
+                frame_bytes[frame_offset] = (uint8_t) (crc & BYTE_MAX);
                 ++frame_offset;
                 ++offset;
             }
         }
 
         // Finalize the frame.
-        CANARD_ASSERT((frame_offset + 1U) == out.tail->base.frame.payload.size);
+        CANARD_ASSERT((frame_offset + 1U) == out.tail->frame.payload.size);
         // SonarQube incorrectly detects a buffer overflow here.
-        out.tail->payload_buffer[frame_offset] =  // NOSONAR
+        frame_bytes[frame_offset] =  // NOSONAR
             txMakeTailByte(out.head == out.tail, offset >= payload_size_with_crc, toggle, transfer_id);
         toggle = !toggle;
     }
@@ -480,12 +486,13 @@ CANARD_PRIVATE TxChain txGenerateMultiFrameChain(CanardTxQueue* const       que,
 }
 
 /// Returns the number of frames enqueued or error.
-CANARD_PRIVATE int32_t txPushMultiFrame(CanardTxQueue* const       que,
-                                        const size_t               presentation_layer_mtu,
-                                        const CanardMicrosecond    deadline_usec,
-                                        const uint32_t             can_id,
-                                        const CanardTransferID     transfer_id,
-                                        const struct CanardPayload payload)
+CANARD_PRIVATE int32_t txPushMultiFrame(CanardTxQueue* const        que,
+                                        const CanardInstance* const ins,
+                                        const size_t                presentation_layer_mtu,
+                                        const CanardMicrosecond     deadline_usec,
+                                        const uint32_t              can_id,
+                                        const CanardTransferID      transfer_id,
+                                        const struct CanardPayload  payload)
 {
     CANARD_ASSERT(que != NULL);
     CANARD_ASSERT(presentation_layer_mtu > 0U);
@@ -498,10 +505,10 @@ CANARD_PRIVATE int32_t txPushMultiFrame(CanardTxQueue* const       que,
     if ((que->size + num_frames) <= que->capacity)  // Bail early if we can see that we won't fit anyway.
     {
         const TxChain sq =
-            txGenerateMultiFrameChain(que, presentation_layer_mtu, deadline_usec, can_id, transfer_id, payload);
+            txGenerateMultiFrameChain(que, ins, presentation_layer_mtu, deadline_usec, can_id, transfer_id, payload);
         if (sq.tail != NULL)
         {
-            CanardTxQueueItem* next = &sq.head->base;
+            CanardTxQueueItem* next = sq.head;
             do
             {
                 const CanardTreeNode* const res =
@@ -520,11 +527,11 @@ CANARD_PRIVATE int32_t txPushMultiFrame(CanardTxQueue* const       que,
         else
         {
             out                     = -CANARD_ERROR_OUT_OF_MEMORY;
-            CanardTxQueueItem* head = &sq.head->base;
+            CanardTxQueueItem* head = sq.head;
             while (head != NULL)
             {
                 CanardTxQueueItem* const next = head->next_in_transfer;
-                que->memory.deallocate(que->memory.user_reference, head->allocated_size, head);
+                canardTxFree(que, ins, head);
                 head = next;
             }
         }
@@ -1066,12 +1073,18 @@ int32_t canardTxPush(CanardTxQueue* const                que,
         {
             if (payload.size <= pl_mtu)
             {
-                out = txPushSingleFrame(que, tx_deadline_usec, (uint32_t) maybe_can_id, metadata->transfer_id, payload);
+                out = txPushSingleFrame(que,
+                                        ins,
+                                        tx_deadline_usec,
+                                        (uint32_t) maybe_can_id,
+                                        metadata->transfer_id,
+                                        payload);
                 CANARD_ASSERT((out < 0) || (out == 1));
             }
             else
             {
                 out = txPushMultiFrame(que,
+                                       ins,
                                        pl_mtu,
                                        tx_deadline_usec,
                                        (uint32_t) maybe_can_id,
@@ -1118,6 +1131,21 @@ CanardTxQueueItem* canardTxPop(CanardTxQueue* const que, const CanardTxQueueItem
         que->size--;
     }
     return out;
+}
+
+void canardTxFree(CanardTxQueue* const que, const CanardInstance* const ins, CanardTxQueueItem* item)
+{
+    if (item != NULL)
+    {
+        if (item->frame.payload.data != NULL)
+        {
+            que->memory.deallocate(que->memory.user_reference,
+                                   item->frame.payload.allocated_size,
+                                   item->frame.payload.data);
+        }
+
+        ins->memory.deallocate(ins->memory.user_reference, sizeof(CanardTxQueueItem), item);
+    }
 }
 
 int8_t canardRxAccept(CanardInstance* const        ins,

--- a/libcanard/canard.h
+++ b/libcanard/canard.h
@@ -269,7 +269,7 @@ typedef struct
 } CanardTransferMetadata;
 
 /// A pointer to the memory allocation function. The semantics are similar to malloc():
-///     - The returned pointer shall point to an uninitialized block of memory that is at least "amount" bytes large.
+///     - The returned pointer shall point to an uninitialized block of memory that is at least `size` bytes large.
 ///     - If there is not enough memory, the returned pointer shall be NULL.
 ///     - The memory shall be aligned at least at max_align_t.
 ///     - The execution time should be constant (O(1)).
@@ -347,9 +347,9 @@ typedef struct CanardTxQueue
     /// If the application knows its MTU, it can use block allocation to avoid extrinsic fragmentation,
     /// as well as a dedicated memory pool specifically for the TX queue payload for transmission.
     /// Dedicated memory resources could be useful also for systems with special memory requirements for payload data.
-    /// For example, such a memory resource could be integrated with a peripheral DMA controller. So that
-    /// memory is allocated directly in the peripheral's memory space. Then it will be filled with payload data by
-    /// the Canard, and finally it will be ready to be directly transmitted by DMA HW (avoiding the need for copying).
+    /// For example, such a memory resource could be integrated with the CAN message RAM. So that memory
+    /// is allocated directly in the peripheral's memory space. Then it will be filled with payload data by
+    /// the Canard, and finally it will be ready to be directly transmitted by the HW (avoiding the need for copying).
     struct CanardMemoryResource memory;
 
     /// This field can be arbitrarily mutated by the user. It is never accessed by the library.
@@ -553,7 +553,7 @@ int32_t canardTxPush(CanardTxQueue* const                que,
 ///
 /// If the queue is non-empty, the returned value is a pointer to its top element (i.e., the next frame to transmit).
 /// The returned pointer points to an object allocated in the dynamic storage; it should be eventually freed by the
-/// application by calling `udpardTxFree`. The memory shall not be freed before the entry is removed
+/// application by calling `canardTxFree`. The memory shall not be freed before the entry is removed
 /// from the queue by calling canardTxPop(); this is because until canardTxPop() is executed, the library retains
 /// ownership of the object. The pointer retains validity until explicitly freed by the application; in other words,
 /// calling canardTxPop() does not invalidate the object.
@@ -587,7 +587,7 @@ CanardTxQueueItem* canardTxPop(CanardTxQueue* const que, const CanardTxQueueItem
 /// as well as the internal frame payload buffer (if any) associated with it (using TX queue memory).
 /// If the item argument is NULL, the function has no effect. The time complexity is constant.
 /// If the item frame payload is NULL then it is assumed that the payload buffer was already freed,
-/// or moved to different ownership (f.e. to media layer).
+/// or moved to a different owner (f.e. to media layer).
 void canardTxFree(CanardTxQueue* const que, const CanardInstance* const ins, CanardTxQueueItem* const item);
 
 /// This function implements the transfer reassembly logic. It accepts a transport frame from any of the redundant

--- a/tests/exposed.hpp
+++ b/tests/exposed.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "canard.h"
-#include <cstdarg>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <stdexcept>

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -193,7 +193,7 @@ public:
 
     [[nodiscard]] auto rxAccept(const CanardMicrosecond      timestamp_usec,
                                 const CanardFrame&           frame,
-                                const uint8_t                redundant_iface_index,
+                                const std::uint8_t           redundant_iface_index,
                                 CanardRxTransfer&            out_transfer,
                                 CanardRxSubscription** const out_subscription)
     {
@@ -327,6 +327,8 @@ public:
         checkInvariants();
         return static_cast<exposed::TxItem*>(out);  // NOLINT static downcast
     }
+
+    void freeItem(Instance& ins, CanardTxQueueItem* const item) { canardTxFree(&que_, &ins.getInstance(), item); }
 
     [[nodiscard]] auto getSize() const
     {

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -188,7 +188,7 @@ public:
 
     [[nodiscard]] auto makeCanardMemoryResource() -> CanardMemoryResource
     {
-        return {this, &Instance::trampolineDeallocate, &Instance::trampolineAllocate};
+        return {this, trampolineDeallocate, trampolineAllocate};
     }
 
     [[nodiscard]] auto rxAccept(const CanardMicrosecond      timestamp_usec,
@@ -250,13 +250,13 @@ public:
 private:
     static auto trampolineAllocate(void* const user_reference, const std::size_t size) -> void*
     {
-        auto* p = reinterpret_cast<Instance*>(user_reference);
+        auto* p = static_cast<Instance*>(user_reference);
         return p->allocator_.allocate(size);
     }
 
     static void trampolineDeallocate(void* const user_reference, const std::size_t size, void* const pointer)
     {
-        auto* p = reinterpret_cast<Instance*>(user_reference);
+        auto* p = static_cast<Instance*>(user_reference);
         p->allocator_.deallocate(pointer, size);
     }
 
@@ -267,7 +267,15 @@ private:
 class TxQueue
 {
 public:
-    explicit TxQueue(const std::size_t capacity, const std::size_t mtu_bytes, const CanardMemoryResource memory) :
+    TxQueue(const std::size_t capacity, const std::size_t mtu_bytes) :
+        que_(canardTxInit(capacity, mtu_bytes, makeCanardMemoryResource()))
+    {
+        enforce(que_.user_reference == nullptr, "Incorrect initialization of the user reference in TxQueue");
+        enforce(que_.mtu_bytes == mtu_bytes, "Incorrect MTU");
+        que_.user_reference = this;  // This is simply to ensure it is not overwritten unexpectedly.
+        checkInvariants();
+    }
+    TxQueue(const std::size_t capacity, const std::size_t mtu_bytes, const CanardMemoryResource memory) :
         que_(canardTxInit(capacity, mtu_bytes, memory))
     {
         enforce(que_.user_reference == nullptr, "Incorrect initialization of the user reference in TxQueue");
@@ -299,14 +307,14 @@ public:
         return ret;
     }
 
-    [[nodiscard]] auto peek() const -> const exposed::TxItem*
+    [[nodiscard]] auto peek() const -> exposed::TxItem*
     {
         checkInvariants();
-        const auto        before = que_.size;
-        const auto* const ret    = canardTxPeek(&que_);
+        const auto  before = que_.size;
+        auto* const ret    = canardTxPeek(&que_);
         enforce(((ret == nullptr) ? (before == 0) : (before > 0)) && (que_.size == before), "Bad peek");
         checkInvariants();
-        return static_cast<const exposed::TxItem*>(ret);  // NOLINT static downcast
+        return static_cast<exposed::TxItem*>(ret);  // NOLINT static downcast
     }
 
     [[nodiscard]] auto pop(const CanardTxQueueItem* const which) -> exposed::TxItem*
@@ -354,7 +362,25 @@ public:
     [[nodiscard]] auto getInstance() -> CanardTxQueue& { return que_; }
     [[nodiscard]] auto getInstance() const -> const CanardTxQueue& { return que_; }
 
+    [[nodiscard]] auto getAllocator() -> TestAllocator& { return allocator_; }
+    [[nodiscard]] auto makeCanardMemoryResource() -> CanardMemoryResource
+    {
+        return {this, trampolineDeallocate, trampolineAllocate};
+    }
+
 private:
+    static auto trampolineAllocate(void* const user_reference, const std::size_t size) -> void*
+    {
+        auto* p = static_cast<TxQueue*>(user_reference);
+        return p->allocator_.allocate(size);
+    }
+
+    static void trampolineDeallocate(void* const user_reference, const std::size_t size, void* const pointer)
+    {
+        auto* p = static_cast<TxQueue*>(user_reference);
+        p->allocator_.deallocate(pointer, size);
+    }
+
     static void enforce(const bool expect_true, const std::string& message)
     {
         if (!expect_true)
@@ -369,6 +395,7 @@ private:
         enforce(que_.size == getSize(), "Size miscalculation");
     }
 
+    TestAllocator allocator_;
     CanardTxQueue que_;
 };
 

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -166,9 +166,8 @@ TEST_CASE("RoundtripSimple")
 
                 CanardRxTransfer      transfer{};
                 CanardRxSubscription* subscription = nullptr;
-                const CanardFrame     frame        = {.extended_can_id = ti->frame.extended_can_id,
-                                                      .payload = {.size = ti->frame.payload.size, .data = ti->frame.payload.data}};
-                const std::int8_t     result = ins_rx.rxAccept(ti->tx_deadline_usec, frame, 0, transfer, &subscription);
+                const CanardFrame frame = {ti->frame.extended_can_id, {ti->frame.payload.size, ti->frame.payload.data}};
+                const std::int8_t result = ins_rx.rxAccept(ti->tx_deadline_usec, frame, 0, transfer, &subscription);
                 REQUIRE(0 == ins_rx.rxAccept(ti->tx_deadline_usec,
                                              frame,
                                              1,


### PR DESCRIPTION
`canardTxPeek` now returns mutable item - needed for payload ownership transfer.