### PR TITLE
Merge v4 into main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh $LLVM_VERSION
-          sudo apt update -y && sudo apt upgrade -y
+          sudo apt-get update -y && sudo apt-get upgrade -y
           sudo apt-get -y install gcc-multilib g++-multilib clang-tidy-$LLVM_VERSION
           sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-$LLVM_VERSION 50
           clang-tidy --version
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{github.job}}
+          name: ${{github.job}}-#${{strategy.job-index}}-${{job.status}}-${{join(matrix.*, ',')}}
           path: ${{github.workspace}}/**/*
           retention-days: 7
           include-hidden-files: true
@@ -62,8 +62,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          sudo apt update -y && sudo apt upgrade -y
-          sudo apt install gcc-multilib g++-multilib
+          sudo apt-get update -y && sudo apt-get upgrade -y
+          sudo apt-get install gcc-multilib g++-multilib
       - run: >
           cmake
           -B ${{ github.workspace }}/build
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{github.job}}
+          name: ${{github.job}}-#${{strategy.job-index}}-${{job.status}}-${{join(matrix.*, ',')}}
           path: ${{github.workspace}}/**/*
           retention-days: 7
           include-hidden-files: true
@@ -93,8 +93,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          sudo apt update -y && sudo apt upgrade -y
-          sudo apt install gcc-avr avr-libc
+          sudo apt-get update -y && sudo apt-get upgrade -y
+          sudo apt-get install gcc-avr avr-libc
           avr-gcc --version
       - run: avr-gcc libcanard/*.c -c -std=c99 -mmcu=${{ env.mcu }} ${{ env.flags }}
       - run: avr-gcc libcanard/*.c -c -std=c11 -mmcu=${{ env.mcu }} ${{ env.flags }}
@@ -109,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          sudo apt update -y && sudo apt upgrade -y
+          sudo apt-get update -y && sudo apt-get upgrade -y
           sudo apt-get install -y gcc-arm-none-eabi
       - run: arm-none-eabi-gcc libcanard/*.c -c -std=c99 ${{ env.flags }}
       - run: arm-none-eabi-gcc libcanard/*.c -c -std=c11 ${{ env.flags }}
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DoozyX/clang-format-lint-action@v0.17
+      - uses: DoozyX/clang-format-lint-action@v0.20
         with:
           source: './libcanard ./tests'
           exclude: './tests/catch'
@@ -146,8 +146,8 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        sudo apt update -y && sudo apt upgrade -y
-        sudo apt install -y gcc-multilib g++-multilib
+        sudo apt-get update -y && sudo apt-get upgrade -y
+        sudo apt-get install -y gcc-multilib g++-multilib
 
     - name: Set up JDK
       uses: actions/setup-java@v4
@@ -203,7 +203,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: ${{github.job}}
+        name: ${{github.job}}-#${{strategy.job-index}}-${{job.status}}-${{join(matrix.*, ',')}}
         path: ${{github.workspace}}/**/*
         retention-days: 7
         include-hidden-files: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,7 +195,7 @@ jobs:
         --define sonar.sources=libcanard
         --define sonar.exclusions=libcanard/_canard_cavl.h
         --define sonar.cfamily.gcov.reportsPath=.
-        --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+        --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"
         --define sonar.host.url="${{ env.SONAR_SERVER_URL }}"
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
-name: Main Workflow
+name: Verification & Static Analysis
 on: [push, pull_request]
 env:
-  LLVM_VERSION: 15
+  LLVM_VERSION: 19
 jobs:
   debug:
     if: github.event_name == 'push'
@@ -37,12 +37,13 @@ jobs:
         run: |
           make VERBOSE=1
           make test
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{github.job}}
           path: ${{github.workspace}}/**/*
-          retention-days: 2
+          retention-days: 7
+          include-hidden-files: true
 
   optimizations:
     if: github.event_name == 'push'
@@ -75,12 +76,13 @@ jobs:
         run: |
           make VERBOSE=1
           make test
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{github.job}}
           path: ${{github.workspace}}/**/*
-          retention-days: 2
+          retention-days: 7
+          include-hidden-files: true
 
   avr:
     if: github.event_name == 'push'
@@ -198,9 +200,10 @@ jobs:
         --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"
         --define sonar.host.url="${{ env.SONAR_SERVER_URL }}"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ${{github.job}}
         path: ${{github.workspace}}/**/*
-        retention-days: 2
+        retention-days: 7
+        include-hidden-files: true

--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="project">
+    <words>
+      <w>candlc</w>
+    </words>
+  </dictionary>
+</component>

--- a/MIGRATION_v3.x_to_v4.0.md
+++ b/MIGRATION_v3.x_to_v4.0.md
@@ -105,7 +105,7 @@ Several functions have updated prototypes and usage patterns:
      - Replaces `payload_size` and `payload` with a single `CanardPayload` struct.
      - Adds a `now_usec` parameter for handling timed-out frames.
        - **Purpose**: Allows the library to automatically drop frames that have exceeded their transmission deadlines (`tx_deadline_usec`).
-       - **Behavior**: If `now_usec` is greater than `tx_deadline_usec`, the frames already in the TX queue will be dropped, and the `dropped_frames` counter in `CanardTxQueueStats` will be incremented.
+       - **Behavior**: If `now_usec` is greater than `tx_deadline_usec`, the frames already in the TX queue will be dropped, and the `frames_expired` counter will be incremented.
        - **Optional Feature**: Passing `0` for `now_usec` disables automatic dropping, maintaining previous behavior.
      - Adds a new `frames_expired` parameter that is incremented for every expired frame, unless NULL.
 
@@ -180,7 +180,6 @@ Several functions have updated prototypes and usage patterns:
 
 - **`CanardTxQueue`**:
   - Includes a `CanardMemoryResource` for payload data allocation.
-  - Includes a `CanardTxQueueStats` for tracking number of dropped frames.
 
 - **`CanardMemoryResource`** and **`CanardMemoryDeleter`**:
   - New structs to encapsulate memory allocation and deallocation functions along with user references.
@@ -219,7 +218,7 @@ Frames in the TX queue that have exceeded their `tx_deadline_usec` can now be au
 
 2. **Adjust Application Logic**:
 
-    - Monitor the `dropped_frames` counter in `CanardTxQueueStats` if tracking of dropped frames is required.
+    - Monitor the statistical counters if tracking of dropped frames is required.
 
 ## Migration Steps
 

--- a/MIGRATION_v3.x_to_v4.0.md
+++ b/MIGRATION_v3.x_to_v4.0.md
@@ -1,0 +1,252 @@
+# Migration Guide: Updating from Libcanard v3.x to v4.0
+
+This guide is intended to help developers migrate their applications from Libcanard version 3.x to version 4.0. It outlines the key changes between the two versions and provides step-by-step instructions to update your code accordingly.
+
+## Introduction
+
+Libcanard is a compact implementation of the Cyphal/CAN protocol designed for high-integrity real-time embedded systems. Version 4 introduces several changes that may impact your existing codebase. This guide will help you understand these changes and update your application accordingly.
+
+These changes do not affect wire compatibility.
+
+## Version Changes
+
+- **Libcanard Version**:
+  - **Old**: `CANARD_VERSION_MAJOR 3`, `CANARD_VERSION_MINOR 3`
+  - **New**: `CANARD_VERSION_MAJOR 4`, `CANARD_VERSION_MINOR 0`
+- **Cyphal Specification Version**: Remains the same (`1.0`).
+
+## API Changes
+
+### New Functions
+
+- **`canardTxFree`**:
+  - **Description**: A helper function to free memory allocated for transmission queue items, including the frame payload buffer.
+  - **Prototype**:
+    ```c
+    void canardTxFree(
+        struct CanardTxQueue* const        que,
+        const struct CanardInstance* const ins,
+        struct CanardTxQueueItem* const    item);
+    ```
+  - **Usage**: After popping a transmission queue item using `canardTxPop`, use `canardTxFree` to deallocate its memory.
+
+### Modified Functions
+
+Several functions have updated prototypes and usage patterns:
+
+1. **`canardInit`**:
+   - **Old Prototype**:
+     ```c
+     CanardInstance canardInit(
+         const CanardMemoryAllocate memory_allocate,
+         const CanardMemoryFree     memory_free);
+     ```
+   - **New Prototype**:
+     ```c
+     struct CanardInstance canardInit(
+         const struct CanardMemoryResource memory);
+     ```
+   - **Changes**:
+     - Replaces `CanardMemoryAllocate` and `CanardMemoryFree` function pointers with a `CanardMemoryResource` struct.
+
+2. **`canardTxInit`**:
+   - **Old Prototype**:
+     ```c
+     CanardTxQueue canardTxInit(
+         const size_t capacity,
+         const size_t mtu_bytes);
+     ```
+   - **New Prototype**:
+     ```c
+     struct CanardTxQueue canardTxInit(
+         const size_t                      capacity,
+         const size_t                      mtu_bytes,
+         const struct CanardMemoryResource memory);
+     ```
+   - **Changes**:
+     - Adds a `CanardMemoryResource` parameter for memory allocation of payload data.
+
+3. **`canardTxPush`**:
+   - **Old Prototype**:
+     ```c
+     int32_t canardTxPush(
+         CanardTxQueue* const                que,
+         CanardInstance* const               ins,
+         const CanardMicrosecond             tx_deadline_usec,
+         const CanardTransferMetadata* const metadata,
+         const size_t                        payload_size,
+         const void* const                   payload);
+     ```
+   - **New Prototype**:
+     ```c
+     int32_t canardTxPush(
+         struct CanardTxQueue* const                que,
+         const struct CanardInstance* const         ins,
+         const CanardMicrosecond                    tx_deadline_usec,
+         const struct CanardTransferMetadata* const metadata,
+         const struct CanardPayload                 payload);
+     ```
+   - **Changes**:
+     - Replaces `payload_size` and `payload` with a single `CanardPayload` struct.
+
+4. **`canardTxPeek`** and **`canardTxPop`**:
+   - The functions now return and accept pointers to mutable `struct CanardTxQueueItem` instead of const pointers.
+
+### Removed Functions
+
+- No functions have been explicitly removed, but some have modified prototypes.
+
+## Data Structure Changes
+
+### Type Definitions
+
+- **Enumerations**:
+  - Changed from `typedef enum` to `enum` without `typedef`.
+  - **Old**:
+    ```c
+    typedef enum { ... } CanardPriority;
+    ```
+  - **New**:
+    ```c
+    enum CanardPriority { ... };
+    ```
+
+- **Structures**:
+  - Changed from forward declarations and `typedef struct` to direct `struct` definitions.
+  - **Old**:
+    ```c
+    typedef struct CanardInstance CanardInstance;
+    ```
+  - **New**:
+    ```c
+    struct CanardInstance { ... };
+    ```
+
+### Struct Modifications
+
+- **`CanardFrame`**:
+  - **Old**:
+    ```c
+    typedef struct {
+        uint32_t extended_can_id;
+        size_t   payload_size;
+        const void* payload;
+    } CanardFrame;
+    ```
+  - **New**:
+    ```c
+    struct CanardFrame {
+        uint32_t extended_can_id;
+        struct CanardPayload payload;
+    };
+    ```
+  - **Changes**:
+    - Payload now uses the `CanardPayload` struct.
+
+- **New Structs Introduced**:
+  - **`CanardPayload`** and **`CanardMutablePayload`**: Encapsulate payload data and size.
+  - **`CanardMutableFrame`**: Similar to `CanardFrame` but uses `CanardMutablePayload`.
+
+- **`CanardInstance`**:
+  - Now contains a `CanardMemoryResource` for memory management instead of separate function pointers.
+
+- **`CanardTxQueue`**:
+  - Includes a `CanardMemoryResource` for payload data allocation.
+
+- **`CanardMemoryResource`** and **`CanardMemoryDeleter`**:
+  - New structs to encapsulate memory allocation and deallocation functions along with user references.
+
+## Memory Management Changes
+
+- **Memory Resource Structs**:
+  - Memory allocation and deallocation are now handled via `CanardMemoryResource` and `CanardMemoryDeleter` structs.
+  - Functions now receive these structs instead of direct function pointers.
+
+- **Allocation Functions**:
+  - **Allocation**:
+    ```c
+    typedef void* (*CanardMemoryAllocate)(
+        void* const user_reference,
+        const size_t size);
+    ```
+  - **Deallocation**:
+    ```c
+    typedef void (*CanardMemoryDeallocate)(
+        void* const user_reference,
+        const size_t size,
+        void* const pointer);
+    ```
+
+## Migration Steps
+
+1. **Update Type Definitions**:
+   - Replace all `typedef`-based enum and struct types with direct `struct` and `enum` declarations.
+   - For example, change `CanardInstance` to `struct CanardInstance`.
+
+2. **Adjust Memory Management Code**:
+   - Replace separate memory allocation and deallocation function pointers with `CanardMemoryResource` and `CanardMemoryDeleter` structs.
+   - Update function calls and definitions accordingly.
+
+3. **Modify Function Calls**:
+   - Update all function calls to match the new prototypes.
+   - **`canardInit`**:
+     - Before:
+       ```c
+       canardInit(memory_allocate, memory_free);
+       ```
+     - After:
+       ```c
+       struct CanardMemoryResource memory = {
+           .user_reference = ...,
+           .allocate = memory_allocate,
+           .deallocate = memory_free
+       };
+       canardInit(memory);
+       ```
+   - **`canardTxInit`**:
+     - Before:
+       ```c
+       canardTxInit(capacity, mtu_bytes);
+       ```
+     - After:
+       ```c
+       canardTxInit(capacity, mtu_bytes, memory);
+       ```
+   - **`canardTxPush`**:
+     - Before:
+       ```c
+       canardTxPush(que, ins, tx_deadline_usec, metadata, payload_size, payload);
+       ```
+     - After:
+       ```c
+       struct CanardPayload payload_struct = {
+           .size = payload_size,
+           .data = payload
+       };
+       canardTxPush(que, ins, tx_deadline_usec, metadata, payload_struct);
+       ```
+
+4. **Handle New Functions**:
+   - Use `canardTxFree` to deallocate transmission queue items after popping them.
+   - Example:
+     ```c
+     struct CanardTxQueueItem* item = canardTxPeek(&tx_queue);
+     while (item != NULL) {
+         // Transmit the frame...
+         canardTxPop(&tx_queue, item);
+         canardTxFree(&tx_queue, &canard_instance, item);
+         item = canardTxPeek(&tx_queue);
+     }
+     ```
+
+5. **Update Struct Field Access**:
+   - Adjust your code to access struct fields directly, considering the changes in struct definitions.
+   - For example, access `payload.size` instead of `payload_size`.
+
+6. **Adjust Memory Allocation Logic**:
+   - Ensure that your memory allocation and deallocation functions conform to the new prototypes.
+   - Pay attention to the additional `size` parameter in the deallocation function.
+
+7. **Test Thoroughly**:
+   - After making the changes, thoroughly test your application to ensure that it functions correctly with the new library version.
+   - Pay special attention to memory management and potential leaks.

--- a/MIGRATION_v3.x_to_v4.0.md
+++ b/MIGRATION_v3.x_to_v4.0.md
@@ -30,6 +30,24 @@ These changes do not affect wire compatibility.
     ```
   - **Usage**: After popping a transmission queue item using `canardTxPop`, use `canardTxFree` to deallocate its memory.
 
+- **`canardTxPoll`**:
+  - **Description**: A helper function simplifies the transmission process by combining frame retrieval, transmission, and cleanup into a single function.
+  - **Prototype**:
+    ```c
+    int8_t canardTxPoll(
+        struct CanardTxQueue* const        que,
+        const struct CanardInstance* const ins,
+        const CanardMicrosecond            now_usec,
+        void* const                        user_reference,
+        const CanardTxFrameHandler         frame_handler
+    ```
+    - **Purpose**: Streamlines the process of handling frames from the TX queue.
+    - **Functionality**:
+      - Retrieves the next frame to be transmitted.
+      - Invokes a user-provided `frame_handler` to transmit the frame.
+      - Manages frame cleanup based on the handler's return value.
+      - Automatically drops timed-out frames if `now_usec` is provided.
+
 ### Modified Functions
 
 Several functions have updated prototypes and usage patterns:
@@ -49,7 +67,7 @@ Several functions have updated prototypes and usage patterns:
    - **Changes**:
      - Replaces `CanardMemoryAllocate` and `CanardMemoryFree` function pointers with a `CanardMemoryResource` struct.
 
-2. **`canardTxInit`**:
+1. **`canardTxInit`**:
    - **Old Prototype**:
      ```c
      CanardTxQueue canardTxInit(
@@ -66,7 +84,7 @@ Several functions have updated prototypes and usage patterns:
    - **Changes**:
      - Adds a `CanardMemoryResource` parameter for memory allocation of payload data.
 
-3. **`canardTxPush`**:
+1. **`canardTxPush`**:
    - **Old Prototype**:
      ```c
      int32_t canardTxPush(
@@ -84,12 +102,17 @@ Several functions have updated prototypes and usage patterns:
          const struct CanardInstance* const         ins,
          const CanardMicrosecond                    tx_deadline_usec,
          const struct CanardTransferMetadata* const metadata,
-         const struct CanardPayload                 payload);
+         const struct CanardPayload                 payload,
+         const CanardMicrosecond                    now_usec);
      ```
    - **Changes**:
      - Replaces `payload_size` and `payload` with a single `CanardPayload` struct.
+     - Adds a `now_usec` parameter for handling timed-out frames.
+       - **Purpose**: Allows the library to automatically drop frames that have exceeded their transmission deadlines (`tx_deadline_usec`).
+       - **Behavior**: If `now_usec` is greater than `tx_deadline_usec`, the frames already in the TX queue will be dropped, and the `dropped_frames` counter in `CanardTxQueueStats` will be incremented.
+       - **Optional Feature**: Passing `0` for `now_usec` disables automatic dropping, maintaining previous behavior.
 
-4. **`canardTxPeek`** and **`canardTxPop`**:
+1. **`canardTxPeek`** and **`canardTxPop`**:
    - The functions now return and accept pointers to mutable `struct CanardTxQueueItem` instead of const pointers.
 
 ### Removed Functions
@@ -122,6 +145,16 @@ Several functions have updated prototypes and usage patterns:
     struct CanardInstance { ... };
     ```
 
+- **Function pointers**:
+  - **Added** `CanardTxFrameHandler` function pointer type.
+    ```c
+    typedef int8_t (*CanardTxFrameHandler)(
+        void* const                      user_reference,
+        const CanardMicrosecond          deadline_usec,
+        struct CanardMutableFrame* const frame
+    );
+    ``` 
+
 ### Struct Modifications
 
 - **`CanardFrame`**:
@@ -152,6 +185,7 @@ Several functions have updated prototypes and usage patterns:
 
 - **`CanardTxQueue`**:
   - Includes a `CanardMemoryResource` for payload data allocation.
+  - Includes a `CanardTxQueueStats` for tracking number of dropped frames.
 
 - **`CanardMemoryResource`** and **`CanardMemoryDeleter`**:
   - New structs to encapsulate memory allocation and deallocation functions along with user references.
@@ -177,17 +211,37 @@ Several functions have updated prototypes and usage patterns:
         void* const pointer);
     ```
 
+## Automatic Dropping of Timed-Out Frames
+
+#### Description
+
+Frames in the TX queue that have exceeded their `tx_deadline_usec` can now be automatically dropped when `now_usec` is provided to `canardTxPush()` or `canardTxPoll()`.
+
+- **Benefit**: Reduces the worst-case peak memory footprint.
+- **Optional**: Feature can be disabled by passing `0` for `now_usec`.
+
+#### Migration Steps
+
+1. **Enable or Disable Automatic Dropping**:
+
+    - **Enable**: Provide the current time to `now_usec` in both `canardTxPush()` and `canardTxPoll()`.
+    - **Disable**: Pass `0` to `now_usec` to retain manual control.
+
+2. **Adjust Application Logic**:
+
+    - Monitor the `dropped_frames` counter in `CanardTxQueueStats` if tracking of dropped frames is required.
+
 ## Migration Steps
 
 1. **Update Type Definitions**:
    - Replace all `typedef`-based enum and struct types with direct `struct` and `enum` declarations.
    - For example, change `CanardInstance` to `struct CanardInstance`.
 
-2. **Adjust Memory Management Code**:
+1. **Adjust Memory Management Code**:
    - Replace separate memory allocation and deallocation function pointers with `CanardMemoryResource` and `CanardMemoryDeleter` structs.
    - Update function calls and definitions accordingly.
 
-3. **Modify Function Calls**:
+1. **Modify Function Calls**:
    - Update all function calls to match the new prototypes.
    - **`canardInit`**:
      - Before:
@@ -223,30 +277,58 @@ Several functions have updated prototypes and usage patterns:
            .size = payload_size,
            .data = payload
        };
-       canardTxPush(que, ins, tx_deadline_usec, metadata, payload_struct);
+       canardTxPush(que, ins, tx_deadline_usec, metadata, payload_struct, now_usec);
        ```
 
-4. **Handle New Functions**:
+1. **Handle New Functions**:
    - Use `canardTxFree` to deallocate transmission queue items after popping them.
-   - Example:
-     ```c
-     struct CanardTxQueueItem* item = canardTxPeek(&tx_queue);
-     while (item != NULL) {
-         // Transmit the frame...
-         canardTxPop(&tx_queue, item);
-         canardTxFree(&tx_queue, &canard_instance, item);
-         item = canardTxPeek(&tx_queue);
-     }
-     ```
+     - Example:
+       ```c
+       struct CanardTxQueueItem* item = canardTxPeek(&tx_queue);
+       while (item != NULL) {
+           // Transmit the frame...
+           canardTxPop(&tx_queue, item);
+           canardTxFree(&tx_queue, &canard_instance, item);
+           item = canardTxPeek(&tx_queue);
+       }
+       ```
 
-5. **Update Struct Field Access**:
+   - If currently using `canardTxPeek()`, `canardTxPop()`, and `canardTxFree()`, consider replacing that logic with `canardTxPoll()` for simplicity.
+     - Define a function matching the `CanardTxFrameHandler` signature:
+       ```c
+       int8_t myFrameHandler(
+           void* const                user_reference,
+           const CanardMicrosecond    deadline_usec,
+           struct CanardMutableFrame* frame
+       ) {
+           // Implement transmission logic here
+           // Return positive value on success - the frame will be released
+           // Return zero to retry later - the frame will stay in the TX queue
+           // Return negative value on failure - whole transfer (including this frame) will be dropped
+       }
+       ```     
+     - Example:  
+       ```c
+       // Before
+       struct CanardTxQueueItem* item = canardTxPeek(queue);
+       if (item != NULL) {
+           // Handle deadline
+           // Transmit item->frame
+           item = canardTxPop(queue, item);
+           canardTxFree(queue, instance, item);
+       }
+
+       // After
+       int8_t result = canardTxPoll(queue, instance, now_usec, user_reference, myFrameHandler);       
+       ```
+1. **Update Struct Field Access**:
    - Adjust your code to access struct fields directly, considering the changes in struct definitions.
    - For example, access `payload.size` instead of `payload_size`.
 
-6. **Adjust Memory Allocation Logic**:
+1. **Adjust Memory Allocation Logic**:
    - Ensure that your memory allocation and deallocation functions conform to the new prototypes.
    - Pay attention to the additional `size` parameter in the deallocation function.
 
-7. **Test Thoroughly**:
+1. **Test Thoroughly**:
    - After making the changes, thoroughly test your application to ensure that it functions correctly with the new library version.
    - Pay special attention to memory management and potential leaks.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@
 
 -----
 
-Libcanard is a compact implementation of the Cyphal/CAN protocol stack in C99/C11 for high-integrity real-time
-embedded systems.
+Libcanard is a robust implementation of the Cyphal/CAN transport layer in C for high-integrity real-time embedded systems.
 
 [Cyphal](https://opencyphal.org) is an open lightweight data bus standard designed for reliable intravehicular
 communication in aerospace and robotic applications via CAN bus, Ethernet, and other robust transports.
@@ -36,7 +35,7 @@ If you want to contribute, please read [`CONTRIBUTING.md`](/CONTRIBUTING.md).
 - Support for redundant network interfaces.
 - Compatibility with 8/16/32/64-bit platforms.
 - Compatibility with extremely resource-constrained baremetal environments starting from 32K ROM and 32K RAM.
-- Implemented in ≈1000 lines of code.
+- Implemented in ≈1000 SLoC.
 
 ## Platforms
 
@@ -49,11 +48,11 @@ The platform-specific media IO layer (driver) is supposed to be provided by the 
     +-------+-----------------+-------+
             |                 |
     +-------+-------+ +-------+-------+
-    |   Libcanard   | |  Media layer  |
+    |   Libcanard   | |   CAN driver  |
     +---------------+ +-------+-------+
                               |
                       +-------+-------+
-                      |    Hardware   |
+                      | CAN controller|
                       +---------------+
 
 The OpenCyphal Development Team maintains a collection of various platform-specific components in a separate repository
@@ -120,7 +119,8 @@ int32_t result = canardTxPush(&queue,               // Call this once per redund
                               tx_deadline_usec,     // Zero if transmission deadline is not limited.
                               &transfer_metadata,
                               47,                   // Size of the message payload (see Nunavut transpiler).
-                              "\x2D\x00" "Sancho, it strikes me thou art in great fear.");
+                              "\x2D\x00" "Sancho, it strikes me thou art in great fear.",
+                              NULL);
 if (result < 0)
 {
     // An error has occurred: either an argument is invalid, the TX queue is full, or we've run out of memory.
@@ -152,7 +152,7 @@ for (struct CanardTxQueueItem* ti = NULL; (ti = canardTxPeek(&queue)) != NULL;) 
 }
 ```
 
-💡 New in v4.0: optionally, you can now use `canardTxPoll()` that does the above for you.
+💡 New in v4.0: optionally, you can now use `canardTxPoll()` that automates the above for you.
 
 Transfer reception is done by feeding frames into the transfer reassembly state machine
 from any of the redundant interfaces.
@@ -185,7 +185,7 @@ for example, `MyMessage.1.0` may have the maximum size of 100 bytes and the exte
 a revised version `MyMessage.1.1` may have the maximum size anywhere between 0 and 200 bytes.
 Extent values are provided per data type by DSDL transcompilers such as Nunavut.
 
-In Libcanard we use the term "subscription" not only for subjects (messages), but also for services, for simplicity.
+In Libcanard we use the term "subscription" not only for subjects (messages), but also for RPC services.
 
 We can subscribe and unsubscribe at runtime as many times as we want.
 Normally, however, an embedded application would subscribe once and roll with it.
@@ -245,8 +245,7 @@ If you find the examples to be unclear or incorrect, please, open a ticket.
 
 ### v4.0 -- WORK IN PROGRESS
 
-Updating from Libcanard v3 to v4 involves several significant changes,
-especially in memory management and API function prototypes.
+Updating from Libcanard v3 to v4 involves several changes in memory management and TX frame expiration.
 Please follow the [MIGRATION_v3.x_to_v4.0](MIGRATION_v3.x_to_v4.0.md) guide and carefully update your code.
 
 ### v3.2

--- a/README.md
+++ b/README.md
@@ -57,9 +57,6 @@ reused in the target application to speed up the design of the media IO layer (d
 
 ## Example
 
-## TODO: Update to show how to use the new sized de-allocations, and how not to confuse payload_size and allocated_size.
-☝ todo will be addressed as soon as the new API is stable (tx, rx, and "zero copy" aspects).
-
 The example augments the documentation but does not replace it.
 
 The library requires a constant-complexity deterministic dynamic memory allocator.
@@ -68,16 +65,16 @@ so let's suppose that we're using [O1Heap](https://github.com/pavel-kirienko/o1h
 We are going to need basic wrappers:
 
 ```c
-static void* memAllocate(CanardInstance* const canard, const size_t amount)
+static void* memAllocate(void* const user_reference, const size_t size)
 {
-    (void) canard;
-    return o1heapAllocate(my_allocator, amount);
+    (void) user_reference;
+    return o1heapAllocate(my_allocator, size);
 }
 
-static void memFree(CanardInstance* const canard, void* const pointer, const size_t amount)
+static void memFree(void* const user_reference, const size_t size, void* const pointer)
 {
-    (void) canard;
-    (void) amount;
+    (void) user_reference;
+    (void) size;
     o1heapFree(my_allocator, pointer);
 }
 ```
@@ -85,22 +82,26 @@ static void memFree(CanardInstance* const canard, void* const pointer, const siz
 Init a library instance:
 
 ```c
-CanardInstance canard = canardInit(&memAllocate, &memFree);
+const struct CanardMemoryResource memory{nullptr, &memAllocate, &memFree};
+struct CanardInstance canard = canardInit(memory);
 canard.node_id = 42;                        // Defaults to anonymous; can be set up later at any point.
 ```
 
 In order to be able to send transfers over the network, we will need one transmission queue per redundant CAN interface:
 
 ```c
-CanardTxQueue queue = canardTxInit(100,                 // Limit the size of the queue at 100 frames.
-                                   CANARD_MTU_CAN_FD);  // Set MTU = 64 bytes. There is also CANARD_MTU_CAN_CLASSIC.
+const struct CanardMemoryResource tx_memory{nullptr, memAllocate, memFree};
+struct CanardTxQueue queue = canardTxInit(
+    100,                // Limit the size of the queue at 100 frames.
+    CANARD_MTU_CAN_FD,  // Set MTU = 64 bytes. There is also CANARD_MTU_CAN_CLASSIC.
+    tx_memory);
 ```
 
 Publish a message (message serialization not shown):
 
 ```c
 static uint8_t my_message_transfer_id;  // Must be static or heap-allocated to retain state between calls.
-const CanardTransferMetadata transfer_metadata = {
+const struct CanardTransferMetadata transfer_metadata = {
     .priority       = CanardPriorityNominal,
     .transfer_kind  = CanardTransferKindMessage,
     .port_id        = 1234,                       // This is the subject-ID.
@@ -131,7 +132,7 @@ Normally, the following fragment should be invoked periodically to unload the CA
 prioritized transmission queue (or several, if redundant network interfaces are used) into the CAN driver:
 
 ```c
-for (const CanardTxQueueItem* ti = NULL; (ti = canardTxPeek(&queue)) != NULL;)  // Peek at the top of the queue.
+for (struct CanardTxQueueItem* ti = NULL; (ti = canardTxPeek(&queue)) != NULL;)  // Peek at the top of the queue.
 {
     if ((0U == ti->tx_deadline_usec) || (ti->tx_deadline_usec > getCurrentMicroseconds()))  // Check the deadline.
     {
@@ -141,7 +142,7 @@ for (const CanardTxQueueItem* ti = NULL; (ti = canardTxPeek(&queue)) != NULL;)  
         }
     }
     // After the frame is transmitted or if it has timed out while waiting, pop it from the queue and deallocate:
-    canard.memory_free(&canard, canardTxPop(&queue, ti));
+    canardTxFree(&queue, &canard, canardTxPop(&queue, ti));
 }
 ```
 
@@ -150,7 +151,7 @@ from any of the redundant interfaces.
 But first, we need to subscribe:
 
 ```c
-CanardRxSubscription heartbeat_subscription;
+struct CanardRxSubscription heartbeat_subscription;
 (void) canardRxSubscribe(&canard,   // Subscribe to messages uavcan.node.Heartbeat.
                          CanardTransferKindMessage,
                          7509,      // The fixed Subject-ID of the Heartbeat message type (see DSDL definition).
@@ -158,7 +159,7 @@ CanardRxSubscription heartbeat_subscription;
                          CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC,
                          &heartbeat_subscription);
 
-CanardRxSubscription my_service_subscription;
+struct CanardRxSubscription my_service_subscription;
 (void) canardRxSubscribe(&canard,   // Subscribe to an arbitrary service response.
                          CanardTransferKindResponse,  // Specify that we want service responses, not requests.
                          123,       // The Service-ID whose responses we will receive.
@@ -183,7 +184,7 @@ Normally, however, an embedded application would subscribe once and roll with it
 Okay, this is how we receive transfers:
 
 ```c
-CanardRxTransfer transfer;
+struct CanardRxTransfer transfer;
 const int8_t result = canardRxAccept(&canard,
                                      rx_timestamp_usec,          // When the frame was received, in microseconds.
                                      &received_frame,            // The CAN frame received from the bus.
@@ -216,15 +217,15 @@ the number of irrelevant transfers processed in software.
 
 ```c
 // Generate an acceptance filter to receive only uavcan.node.Heartbeat.1.0 messages (fixed port-ID 7509):
-CanardFilter heartbeat_config = canardMakeFilterForSubject(7509);
+struct CanardFilter heartbeat_config = canardMakeFilterForSubject(7509);
 // And to receive only uavcan.register.Access.1.0 service transfers (fixed port-ID 384):
-CanardFilter register_access_config = canardMakeFilterForService(384, ins.node_id);
+struct CanardFilter register_access_config = canardMakeFilterForService(384, ins.node_id);
 
 // You can also combine the two filter configurations into one (may also accept irrelevant messages).
 // This allows consolidating a large set of configurations to fit the number of hardware filters.
 // For more information on the optimal subset of configurations to consolidate to minimize wasted CPU,
 // see the Cyphal specification.
-CanardFilter combined_config =
+struct CanardFilter combined_config =
         canardConsolidateFilters(&heartbeat_config, &register_access_config);
 configureHardwareFilters(combined_config.extended_can_id, combined_config.extended_mask);
 ```
@@ -233,6 +234,11 @@ Full API specification is available in the documentation.
 If you find the examples to be unclear or incorrect, please, open a ticket.
 
 ## Revisions
+
+### v4.0
+
+- Updating from Libcanard v3 to v4 involves several significant changes, especially in memory management and API function prototypes.
+- Please follow [MIGRATION_v3.x_to_v4.0](MIGRATION_v3.x_to_v4.0.md) guide and carefully update your code.
 
 ### v3.2
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ static void* memAllocate(CanardInstance* const canard, const size_t amount)
     return o1heapAllocate(my_allocator, amount);
 }
 
-static void memFree(CanardInstance* const canard, void* const pointer)
+static void memFree(CanardInstance* const canard, void* const pointer, const size_t amount)
 {
     (void) canard;
+    (void) amount;
     o1heapFree(my_allocator, pointer);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Compact Cyphal/CAN in C
+<div align="center">
+
+# Cyphal/CAN transport in C
 
 [![Main Workflow](https://github.com/OpenCyphal/libcanard/actions/workflows/main.yml/badge.svg)](https://github.com/OpenCyphal/libcanard/actions/workflows/main.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=libcanard&metric=alert_status)](https://sonarcloud.io/dashboard?id=libcanard)
@@ -6,6 +8,10 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=libcanard&metric=coverage)](https://sonarcloud.io/dashboard?id=libcanard)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=libcanard&metric=ncloc)](https://sonarcloud.io/dashboard?id=libcanard)
 [![Forum](https://img.shields.io/discourse/users.svg?server=https%3A%2F%2Fforum.opencyphal.org&color=1700b3)](https://forum.opencyphal.org)
+
+</div>
+
+-----
 
 Libcanard is a compact implementation of the Cyphal/CAN protocol stack in C99/C11 for high-integrity real-time
 embedded systems.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ reused in the target application to speed up the design of the media IO layer (d
 
 ## Example
 
+## TODO: Update to show how to use the new sized de-allocations, and how not to confuse payload_size and allocated_size.
+☝ todo will be addressed as soon as the new API is stable (tx, rx, and "zero copy" aspects).
+
 The example augments the documentation but does not replace it.
 
 The library requires a constant-complexity deterministic dynamic memory allocator.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ for (struct CanardTxQueueItem* ti = NULL; (ti = canardTxPeek(&queue)) != NULL;) 
 }
 ```
 
+💡 New in v4.0: optionally, you can now use `canardTxPoll()` that does the above for you.
+
 Transfer reception is done by feeding frames into the transfer reassembly state machine
 from any of the redundant interfaces.
 But first, we need to subscribe:
@@ -235,10 +237,11 @@ If you find the examples to be unclear or incorrect, please, open a ticket.
 
 ## Revisions
 
-### v4.0
+### v4.0 -- WORK IN PROGRESS
 
-- Updating from Libcanard v3 to v4 involves several significant changes, especially in memory management and API function prototypes.
-- Please follow [MIGRATION_v3.x_to_v4.0](MIGRATION_v3.x_to_v4.0.md) guide and carefully update your code.
+Updating from Libcanard v3 to v4 involves several significant changes,
+especially in memory management and API function prototypes.
+Please follow the [MIGRATION_v3.x_to_v4.0](MIGRATION_v3.x_to_v4.0.md) guide and carefully update your code.
 
 ### v3.2
 

--- a/libcanard/.clang-tidy
+++ b/libcanard/.clang-tidy
@@ -21,7 +21,8 @@ Checks: >-
   -cert-dcl03-c,
   -hicpp-static-assert,
   -misc-static-assert,
-  -modernize-macro-to-enum,
+  -*-macro-to-enum,
+  -misc-include-cleaner,
 CheckOptions:
   - key:   readability-function-cognitive-complexity.Threshold
     value: '99'

--- a/libcanard/_canard_cavl.h
+++ b/libcanard/_canard_cavl.h
@@ -43,7 +43,7 @@ extern "C" {
 // ----------------------------------------         PUBLIC API SECTION         ----------------------------------------
 
 /// Modified for use with Libcanard: expose the Cavl structure via public API as CanardTreeNode.
-typedef CanardTreeNode Cavl;
+typedef struct CanardTreeNode Cavl;
 
 /// Returns POSITIVE if the search target is GREATER than the provided node, negative if smaller, zero on match (found).
 /// Values other than {-1, 0, +1} are not recommended to avoid overflow during the narrowing conversion of the result.

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -592,16 +592,44 @@ CANARD_PRIVATE int32_t txPushMultiFrame(struct CanardTxQueue* const        que,
     return out;
 }
 
+CANARD_PRIVATE void txPopAndFreeTransfer(struct CanardTxQueue* const        que,
+                                         const struct CanardInstance* const ins,
+                                         struct CanardTxQueueItem* const    tx_item,
+                                         const bool                         drop_whole_transfer)
+{
+    CANARD_ASSERT(que != NULL);
+    CANARD_ASSERT(ins != NULL);
+    CANARD_ASSERT(tx_item != NULL);
+
+    struct CanardTxQueueItem* next_tx_item    = tx_item;
+    struct CanardTxQueueItem* tx_item_to_free = canardTxPop(que, next_tx_item);
+    while (NULL != tx_item_to_free)
+    {
+        next_tx_item = tx_item_to_free->next_in_transfer;
+        canardTxFree(que, ins, tx_item_to_free);
+
+        if (!drop_whole_transfer)
+        {
+            break;
+        }
+        que->stats.dropped_frames++;
+
+        tx_item_to_free = canardTxPop(que, next_tx_item);
+    }
+}
+
 /// Flushes expired transfers by comparing deadline timestamps of the pending transfers with the current time.
 CANARD_PRIVATE void txFlushExpiredTransfers(struct CanardTxQueue* const        que,
                                             const struct CanardInstance* const ins,
                                             const CanardMicrosecond            now_usec)
 {
-    struct CanardTxQueueItem* tx_item = NULL;
-    while (NULL != (tx_item = MUTABLE_CONTAINER_OF(  //
-                        struct CanardTxQueueItem,
-                        cavlFindExtremum(que->deadline_root, false),
-                        deadline_base)))
+    CANARD_ASSERT(que != NULL);
+    CANARD_ASSERT(ins != NULL);
+    CANARD_ASSERT(now_usec > 0);
+
+    struct CanardTreeNode*    tx_node = cavlFindExtremum(que->deadline_root, false);
+    struct CanardTxQueueItem* tx_item = MUTABLE_CONTAINER_OF(struct CanardTxQueueItem, tx_node, deadline_base);
+    while (NULL != tx_item)
     {
         if (now_usec <= tx_item->tx_deadline_usec)
         {
@@ -609,15 +637,11 @@ CANARD_PRIVATE void txFlushExpiredTransfers(struct CanardTxQueue* const        q
             break;
         }
 
-        // All frames of the transfer are released at once b/c they all have the same deadline.
-        struct CanardTxQueueItem* tx_item_to_free = NULL;
-        while (NULL != (tx_item_to_free = canardTxPop(que, tx_item)))
-        {
-            tx_item = tx_item_to_free->next_in_transfer;
-            canardTxFree(que, ins, tx_item_to_free);
+        // All frames of the transfer are dropped at once b/c they all have the same deadline.
+        txPopAndFreeTransfer(que, ins, tx_item, true);  // drop the whole transfer
 
-            que->stats.dropped_frames++;
-        }
+        tx_node = cavlFindExtremum(que->deadline_root, false);
+        tx_item = MUTABLE_CONTAINER_OF(struct CanardTxQueueItem, tx_node, deadline_base);
     }
 }
 
@@ -1157,8 +1181,6 @@ int32_t canardTxPush(struct CanardTxQueue* const                que,
         txFlushExpiredTransfers(que, ins, now_usec);
     }
 
-    (void) now_usec;
-
     int32_t out = -CANARD_ERROR_INVALID_ARGUMENT;
     if ((ins != NULL) && (que != NULL) && (metadata != NULL) && ((payload.data != NULL) || (0U == payload.size)))
     {
@@ -1202,8 +1224,6 @@ struct CanardTxQueueItem* canardTxPeek(const struct CanardTxQueue* const que)
     struct CanardTxQueueItem* out = NULL;
     if (que != NULL)
     {
-        // Paragraph 6.7.2.1.15 of the C standard says:
-        //     A pointer to a structure object, suitably converted, points to its initial member, and vice versa.
         struct CanardTreeNode* const priority_node = cavlFindExtremum(que->priority_root, false);
         out = MUTABLE_CONTAINER_OF(struct CanardTxQueueItem, priority_node, priority_base);
     }
@@ -1229,7 +1249,7 @@ void canardTxFree(struct CanardTxQueue* const        que,
                   const struct CanardInstance* const ins,
                   struct CanardTxQueueItem*          item)
 {
-    if (item != NULL)
+    if ((que != NULL) && (ins != NULL) && (item != NULL))
     {
         if (item->frame.payload.data != NULL)
         {
@@ -1240,6 +1260,53 @@ void canardTxFree(struct CanardTxQueue* const        que,
 
         ins->memory.deallocate(ins->memory.user_reference, sizeof(struct CanardTxQueueItem), item);
     }
+}
+
+int8_t canardTxPoll(struct CanardTxQueue* const        que,
+                    const struct CanardInstance* const ins,
+                    const CanardMicrosecond            now_usec,
+                    void* const                        user_reference,
+                    const CanardTxFrameHandler         frame_handler)
+{
+    int8_t out = -CANARD_ERROR_INVALID_ARGUMENT;
+    if ((que != NULL) && (ins != NULL) && (frame_handler != NULL))
+    {
+        // Before peeking a frame to transmit, we need to try to flush any expired transfers.
+        // This will not only ensure ASAP freeing of the queue capacity, but also makes sure that the following
+        // `canardTxPeek` will return a not expired item (if any), so we don't need to check the deadline again.
+        // The flushing is done by comparing deadline timestamps of the pending transfers with the current time,
+        // which makes sense only if the current time is known (bigger than zero).
+        if (now_usec > 0)
+        {
+            txFlushExpiredTransfers(que, ins, now_usec);
+        }
+
+        struct CanardTxQueueItem* const tx_item = canardTxPeek(que);
+        if (tx_item != NULL)
+        {
+            // No need to check the deadline again, as we have already flushed all expired transfers.
+            out = frame_handler(user_reference, tx_item->tx_deadline_usec, &tx_item->frame);
+
+            // We gonna release (pop and free) the frame if the handler returned:
+            // - either a positive value - the frame has been successfully accepted by the handler;
+            // - or a negative value - the frame has been rejected by the handler due to a failure.
+            // Zero value means that the handler cannot accept the frame at the moment, so we keep it in the queue.
+            if (out != 0)
+            {
+                // In case of a failure, it makes sense to drop the whole transfer immediately
+                // b/c at least this frame has been rejected, so the whole transfer is useless.
+                const bool drop_whole_transfer = (out < 0);
+                txPopAndFreeTransfer(que, ins, tx_item, drop_whole_transfer);
+            }
+        }
+        else
+        {
+            out = 0;  // No frames to transmit.
+        }
+    }
+
+    CANARD_ASSERT(out <= 1);
+    return out;
 }
 
 int8_t canardRxAccept(struct CanardInstance* const        ins,
@@ -1261,13 +1328,12 @@ int8_t canardRxAccept(struct CanardInstance* const        ins,
                 // This is the reason the function has a logarithmic time complexity of the number of subscriptions.
                 // Note also that this one of the two variable-complexity operations in the RX pipeline; the other one
                 // is memcpy(). Excepting these two cases, the entire RX pipeline contains neither loops nor recursion.
-                struct CanardRxSubscription* const sub = MUTABLE_CONTAINER_OF(  //
-                    struct CanardRxSubscription,
-                    cavlSearch(&ins->rx_subscriptions[(size_t) model.transfer_kind],
-                               &model.port_id,
-                               &rxSubscriptionPredicateOnPortID,
-                               NULL),
-                    base);
+                struct CanardTreeNode* const sub_node = cavlSearch(&ins->rx_subscriptions[(size_t) model.transfer_kind],
+                                                                   &model.port_id,
+                                                                   &rxSubscriptionPredicateOnPortID,
+                                                                   NULL);
+                struct CanardRxSubscription* const sub =
+                    MUTABLE_CONTAINER_OF(struct CanardRxSubscription, sub_node, base);
                 if (out_subscription != NULL)
                 {
                     *out_subscription = sub;  // Expose selected instance to the caller.
@@ -1345,13 +1411,15 @@ int8_t canardRxUnsubscribe(struct CanardInstance* const  ins,
     {
         CanardPortID port_id_mutable = port_id;
 
-        struct CanardRxSubscription* const sub = MUTABLE_CONTAINER_OF(  //
-            struct CanardRxSubscription,
-            cavlSearch(&ins->rx_subscriptions[tk], &port_id_mutable, &rxSubscriptionPredicateOnPortID, NULL),
-            base);
-        if (sub != NULL)
+        struct CanardTreeNode* const sub_node = cavlSearch(  //
+            &ins->rx_subscriptions[tk],
+            &port_id_mutable,
+            &rxSubscriptionPredicateOnPortID,
+            NULL);
+        if (sub_node != NULL)
         {
-            cavlRemove(&ins->rx_subscriptions[tk], &sub->base);
+            struct CanardRxSubscription* const sub = MUTABLE_CONTAINER_OF(struct CanardRxSubscription, sub_node, base);
+            cavlRemove(&ins->rx_subscriptions[tk], sub_node);
             CANARD_ASSERT(sub->port_id == port_id);
             out = 1;
             for (size_t i = 0; i < RX_SESSIONS_PER_SUBSCRIPTION; i++)
@@ -1386,12 +1454,14 @@ int8_t canardRxGetSubscription(struct CanardInstance* const        ins,
     {
         CanardPortID port_id_mutable = port_id;
 
-        struct CanardRxSubscription* const sub = MUTABLE_CONTAINER_OF(  //
-            struct CanardRxSubscription,
-            cavlSearch(&ins->rx_subscriptions[tk], &port_id_mutable, &rxSubscriptionPredicateOnPortID, NULL),
-            base);
-        if (sub != NULL)
+        struct CanardTreeNode* const sub_node = cavlSearch(  //
+            &ins->rx_subscriptions[tk],
+            &port_id_mutable,
+            &rxSubscriptionPredicateOnPortID,
+            NULL);
+        if (sub_node != NULL)
         {
+            struct CanardRxSubscription* const sub = MUTABLE_CONTAINER_OF(struct CanardRxSubscription, sub_node, base);
             CANARD_ASSERT(sub->port_id == port_id);
             if (out_subscription != NULL)
             {

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -1,5 +1,5 @@
 /// This software is distributed under the terms of the MIT License.
-/// Copyright (c) 2016 OpenCyphal.
+/// Copyright (c) OpenCyphal.
 /// Author: Pavel Kirienko <pavel@opencyphal.org>
 
 #include "canard.h"

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -3,6 +3,7 @@
 /// Author: Pavel Kirienko <pavel@opencyphal.org>
 
 #include "canard.h"
+#include <stddef.h>
 #include <string.h>
 
 // --------------------------------------------- BUILD CONFIGURATION ---------------------------------------------
@@ -69,6 +70,11 @@
 #define TAIL_TOGGLE 32U
 
 #define INITIAL_TOGGLE_STATE true
+
+#define CONTAINER_OF(type, ptr, member) \
+    ((const type*) (((ptr) == NULL) ? NULL : (const void*) (((const char*) (ptr)) - offsetof(type, member))))
+#define MUTABLE_CONTAINER_OF(type, ptr, member) \
+    ((type*) (((ptr) == NULL) ? NULL : (void*) (((char*) (ptr)) - offsetof(type, member))))
 
 /// Used for inserting new items into AVL trees.
 CANARD_PRIVATE struct CanardTreeNode* avlTrivialFactory(void* const user_reference)
@@ -299,10 +305,15 @@ CANARD_PRIVATE struct CanardTxQueueItem* txAllocateQueueItem(struct CanardTxQueu
     struct CanardTxQueueItem* out = ins->memory.allocate(ins->memory.user_reference, sizeof(struct CanardTxQueueItem));
     if (out != NULL)
     {
-        out->base.up    = NULL;
-        out->base.lr[0] = NULL;
-        out->base.lr[1] = NULL;
-        out->base.bf    = 0;
+        out->priority_base.up    = NULL;
+        out->priority_base.lr[0] = NULL;
+        out->priority_base.lr[1] = NULL;
+        out->priority_base.bf    = 0;
+
+        out->deadline_base.up    = NULL;
+        out->deadline_base.lr[0] = NULL;
+        out->deadline_base.lr[1] = NULL;
+        out->deadline_base.bf    = 0;
 
         out->next_in_transfer = NULL;  // Last by default.
         out->tx_deadline_usec = deadline_usec;
@@ -329,13 +340,32 @@ CANARD_PRIVATE struct CanardTxQueueItem* txAllocateQueueItem(struct CanardTxQueu
 /// Frames with identical CAN ID that are added later always compare greater than their counterparts with same CAN ID.
 /// This ensures that CAN frames with the same CAN ID are transmitted in the FIFO order.
 /// Frames that should be transmitted earlier compare smaller (i.e., put on the left side of the tree).
-CANARD_PRIVATE int8_t txAVLPredicate(void* const user_reference,  // NOSONAR Cavl API requires pointer to non-const.
-                                     const struct CanardTreeNode* const node)
+CANARD_PRIVATE int8_t txAVLPriorityPredicate(           //
+    void* const                        user_reference,  // NOSONAR Cavl API requires pointer to non-const.
+    const struct CanardTreeNode* const node)
 {
-    const struct CanardTxQueueItem* const target = (const struct CanardTxQueueItem*) user_reference;
-    const struct CanardTxQueueItem* const other  = (const struct CanardTxQueueItem*) (const void*) node;
+    typedef struct CanardTxQueueItem TxItem;
+
+    const TxItem* const target = CONTAINER_OF(TxItem, user_reference, priority_base);
+    const TxItem* const other  = CONTAINER_OF(TxItem, node, priority_base);
     CANARD_ASSERT((target != NULL) && (other != NULL));
     return (target->frame.extended_can_id >= other->frame.extended_can_id) ? +1 : -1;
+}
+
+/// Frames with identical deadline
+/// that are added later always compare greater than their counterparts with the same deadline.
+/// This ensures that CAN frames with the same deadline are, when timed out, dropped in the FIFO order.
+/// Frames that should be dropped earlier compare smaller (i.e., put on the left side of the tree).
+CANARD_PRIVATE int8_t txAVLDeadlinePredicate(           //
+    void* const                        user_reference,  // NOSONAR Cavl API requires pointer to non-const.
+    const struct CanardTreeNode* const node)
+{
+    typedef struct CanardTxQueueItem TxItem;
+
+    const TxItem* const target = CONTAINER_OF(TxItem, user_reference, deadline_base);
+    const TxItem* const other  = CONTAINER_OF(TxItem, node, deadline_base);
+    CANARD_ASSERT((target != NULL) && (other != NULL));
+    return (target->tx_deadline_usec >= other->tx_deadline_usec) ? +1 : -1;
 }
 
 /// Returns the number of frames enqueued or error (i.e., =1 or <0).
@@ -369,11 +399,19 @@ CANARD_PRIVATE int32_t txPushSingleFrame(struct CanardTxQueue* const        que,
         uint8_t* const frame_bytes = tqi->frame.payload.data;
         (void) memset(frame_bytes + payload.size, PADDING_BYTE_VALUE, padding_size);  // NOLINT
         *(frame_bytes + (frame_payload_size - 1U)) = txMakeTailByte(true, true, true, transfer_id);
-        // Insert the newly created TX item into the queue.
-        const struct CanardTreeNode* const res =
-            cavlSearch(&que->root, &tqi->base, &txAVLPredicate, &avlTrivialFactory);
-        (void) res;
-        CANARD_ASSERT(res == &tqi->base);
+
+        // Insert the newly created TX item into the priority queue.
+        const struct CanardTreeNode* const priority_queue_res =
+            cavlSearch(&que->priority_root, &tqi->priority_base, &txAVLPriorityPredicate, &avlTrivialFactory);
+        (void) priority_queue_res;
+        CANARD_ASSERT(priority_queue_res == &tqi->priority_base);
+
+        // Insert the newly created TX item into the deadline queue.
+        const struct CanardTreeNode* const deadline_queue_res =
+            cavlSearch(&que->deadline_root, &tqi->deadline_base, &txAVLDeadlinePredicate, &avlTrivialFactory);
+        (void) deadline_queue_res;
+        CANARD_ASSERT(deadline_queue_res == &tqi->deadline_base);
+
         que->size++;
         CANARD_ASSERT(que->size <= que->capacity);
         out = 1;  // One frame enqueued.
@@ -514,11 +552,18 @@ CANARD_PRIVATE int32_t txPushMultiFrame(struct CanardTxQueue* const        que,
             struct CanardTxQueueItem* next = sq.head;
             do
             {
-                const struct CanardTreeNode* const res =
-                    cavlSearch(&que->root, &next->base, &txAVLPredicate, &avlTrivialFactory);
-                (void) res;
-                CANARD_ASSERT(res == &next->base);
-                CANARD_ASSERT(que->root != NULL);
+                const struct CanardTreeNode* const priority_queue_res =
+                    cavlSearch(&que->priority_root, &next->priority_base, &txAVLPriorityPredicate, &avlTrivialFactory);
+                (void) priority_queue_res;
+                CANARD_ASSERT(priority_queue_res == &next->priority_base);
+                CANARD_ASSERT(que->priority_root != NULL);
+
+                const struct CanardTreeNode* const deadline_queue_res =
+                    cavlSearch(&que->deadline_root, &next->deadline_base, &txAVLDeadlinePredicate, &avlTrivialFactory);
+                (void) deadline_queue_res;
+                CANARD_ASSERT(deadline_queue_res == &next->deadline_base);
+                CANARD_ASSERT(que->deadline_root != NULL);
+
                 next = next->next_in_transfer;
             } while (next != NULL);
             CANARD_ASSERT(num_frames == sq.size);
@@ -545,6 +590,35 @@ CANARD_PRIVATE int32_t txPushMultiFrame(struct CanardTxQueue* const        que,
     }
     CANARD_ASSERT((out < 0) || (out >= 2));
     return out;
+}
+
+/// Flushes expired transfers by comparing deadline timestamps of the pending transfers with the current time.
+CANARD_PRIVATE void txFlushExpiredTransfers(struct CanardTxQueue* const        que,
+                                            const struct CanardInstance* const ins,
+                                            const CanardMicrosecond            now_usec)
+{
+    struct CanardTxQueueItem* tx_item = NULL;
+    while (NULL != (tx_item = MUTABLE_CONTAINER_OF(  //
+                        struct CanardTxQueueItem,
+                        cavlFindExtremum(que->deadline_root, false),
+                        deadline_base)))
+    {
+        if (now_usec <= tx_item->tx_deadline_usec)
+        {
+            // The queue is sorted by deadline, so we can stop here.
+            break;
+        }
+
+        // All frames of the transfer are released at once b/c they all have the same deadline.
+        struct CanardTxQueueItem* tx_item_to_free = NULL;
+        while (NULL != (tx_item_to_free = canardTxPop(que, tx_item)))
+        {
+            tx_item = tx_item_to_free->next_in_transfer;
+            canardTxFree(que, ins, tx_item_to_free);
+
+            que->stats.dropped_frames++;
+        }
+    }
 }
 
 // --------------------------------------------- RECEPTION ---------------------------------------------
@@ -1005,8 +1079,9 @@ CANARD_PRIVATE int8_t
 rxSubscriptionPredicateOnPortID(void* const user_reference,  // NOSONAR Cavl API requires pointer to non-const.
                                 const struct CanardTreeNode* const node)
 {
+    CANARD_ASSERT((user_reference != NULL) && (node != NULL));
     const CanardPortID  sought    = *((const CanardPortID*) user_reference);
-    const CanardPortID  other     = ((const struct CanardRxSubscription*) (const void*) node)->port_id;
+    const CanardPortID  other     = CONTAINER_OF(struct CanardRxSubscription, node, base)->port_id;
     static const int8_t NegPos[2] = {-1, +1};
     // Clang-Tidy mistakenly identifies a narrowing cast to int8_t here, which is incorrect.
     return (sought == other) ? 0 : NegPos[sought > other];  // NOLINT no narrowing conversion is taking place here
@@ -1016,7 +1091,9 @@ CANARD_PRIVATE int8_t
 rxSubscriptionPredicateOnStruct(void* const user_reference,  // NOSONAR Cavl API requires pointer to non-const.
                                 const struct CanardTreeNode* const node)
 {
-    return rxSubscriptionPredicateOnPortID(&((struct CanardRxSubscription*) user_reference)->port_id, node);
+    return rxSubscriptionPredicateOnPortID(  //
+        &MUTABLE_CONTAINER_OF(struct CanardRxSubscription, user_reference, base)->port_id,
+        node);
 }
 
 // --------------------------------------------- PUBLIC API ---------------------------------------------
@@ -1056,7 +1133,8 @@ struct CanardTxQueue canardTxInit(const size_t                      capacity,
         .capacity       = capacity,
         .mtu_bytes      = mtu_bytes,
         .size           = 0,
-        .root           = NULL,
+        .priority_root  = NULL,
+        .deadline_root  = NULL,
         .memory         = memory,
         .user_reference = NULL,
     };
@@ -1067,8 +1145,20 @@ int32_t canardTxPush(struct CanardTxQueue* const                que,
                      const struct CanardInstance* const         ins,
                      const CanardMicrosecond                    tx_deadline_usec,
                      const struct CanardTransferMetadata* const metadata,
-                     const struct CanardPayload                 payload)
+                     const struct CanardPayload                 payload,
+                     const CanardMicrosecond                    now_usec)
 {
+    // Before pushing payload (potentially in multiple frames), we need to try to flush any expired transfers.
+    // This is necessary to ensure that we don't exhaust the capacity of the queue by holding outdated frames.
+    // The flushing is done by comparing deadline timestamps of the pending transfers with the current time,
+    // which makes sense only if the current time is known (bigger than zero).
+    if (now_usec > 0)
+    {
+        txFlushExpiredTransfers(que, ins, now_usec);
+    }
+
+    (void) now_usec;
+
     int32_t out = -CANARD_ERROR_INVALID_ARGUMENT;
     if ((ins != NULL) && (que != NULL) && (metadata != NULL) && ((payload.data != NULL) || (0U == payload.size)))
     {
@@ -1114,7 +1204,8 @@ struct CanardTxQueueItem* canardTxPeek(const struct CanardTxQueue* const que)
     {
         // Paragraph 6.7.2.1.15 of the C standard says:
         //     A pointer to a structure object, suitably converted, points to its initial member, and vice versa.
-        out = (struct CanardTxQueueItem*) (void*) cavlFindExtremum(que->root, false);
+        struct CanardTreeNode* const priority_node = cavlFindExtremum(que->priority_root, false);
+        out = MUTABLE_CONTAINER_OF(struct CanardTxQueueItem, priority_node, priority_base);
     }
     return out;
 }
@@ -1127,7 +1218,8 @@ struct CanardTxQueueItem* canardTxPop(struct CanardTxQueue* const que, struct Ca
         //     A pointer to a structure object, suitably converted, points to its initial member, and vice versa.
         // Note that the highest-priority frame is always a leaf node in the AVL tree, which means that it is very
         // cheap to remove.
-        cavlRemove(&que->root, &item->base);
+        cavlRemove(&que->priority_root, &item->priority_base);
+        cavlRemove(&que->deadline_root, &item->deadline_base);
         que->size--;
     }
     return item;
@@ -1169,11 +1261,13 @@ int8_t canardRxAccept(struct CanardInstance* const        ins,
                 // This is the reason the function has a logarithmic time complexity of the number of subscriptions.
                 // Note also that this one of the two variable-complexity operations in the RX pipeline; the other one
                 // is memcpy(). Excepting these two cases, the entire RX pipeline contains neither loops nor recursion.
-                struct CanardRxSubscription* const sub = (struct CanardRxSubscription*) (void*)
+                struct CanardRxSubscription* const sub = MUTABLE_CONTAINER_OF(  //
+                    struct CanardRxSubscription,
                     cavlSearch(&ins->rx_subscriptions[(size_t) model.transfer_kind],
                                &model.port_id,
                                &rxSubscriptionPredicateOnPortID,
-                               NULL);
+                               NULL),
+                    base);
                 if (out_subscription != NULL)
                 {
                     *out_subscription = sub;  // Expose selected instance to the caller.
@@ -1230,7 +1324,7 @@ int8_t canardRxSubscribe(struct CanardInstance* const       ins,
                 out_subscription->sessions[i] = NULL;
             }
             const struct CanardTreeNode* const res = cavlSearch(&ins->rx_subscriptions[tk],
-                                                                out_subscription,
+                                                                &out_subscription->base,
                                                                 &rxSubscriptionPredicateOnStruct,
                                                                 &avlTrivialFactory);
             (void) res;
@@ -1249,9 +1343,12 @@ int8_t canardRxUnsubscribe(struct CanardInstance* const  ins,
     const size_t tk  = (size_t) transfer_kind;
     if ((ins != NULL) && (tk < CANARD_NUM_TRANSFER_KINDS))
     {
-        CanardPortID                       port_id_mutable = port_id;
-        struct CanardRxSubscription* const sub             = (struct CanardRxSubscription*) (void*)
-            cavlSearch(&ins->rx_subscriptions[tk], &port_id_mutable, &rxSubscriptionPredicateOnPortID, NULL);
+        CanardPortID port_id_mutable = port_id;
+
+        struct CanardRxSubscription* const sub = MUTABLE_CONTAINER_OF(  //
+            struct CanardRxSubscription,
+            cavlSearch(&ins->rx_subscriptions[tk], &port_id_mutable, &rxSubscriptionPredicateOnPortID, NULL),
+            base);
         if (sub != NULL)
         {
             cavlRemove(&ins->rx_subscriptions[tk], &sub->base);
@@ -1287,9 +1384,12 @@ int8_t canardRxGetSubscription(struct CanardInstance* const        ins,
     const size_t tk  = (size_t) transfer_kind;
     if ((ins != NULL) && (tk < CANARD_NUM_TRANSFER_KINDS))
     {
-        CanardPortID                       port_id_mutable = port_id;
-        struct CanardRxSubscription* const sub             = (struct CanardRxSubscription*) (void*)
-            cavlSearch(&ins->rx_subscriptions[tk], &port_id_mutable, &rxSubscriptionPredicateOnPortID, NULL);
+        CanardPortID port_id_mutable = port_id;
+
+        struct CanardRxSubscription* const sub = MUTABLE_CONTAINER_OF(  //
+            struct CanardRxSubscription,
+            cavlSearch(&ins->rx_subscriptions[tk], &port_id_mutable, &rxSubscriptionPredicateOnPortID, NULL),
+            base);
         if (sub != NULL)
         {
             CANARD_ASSERT(sub->port_id == port_id);

--- a/libcanard/canard.h
+++ b/libcanard/canard.h
@@ -340,8 +340,10 @@ typedef struct CanardTxQueue
     /// The root of the priority queue is NULL if the queue is empty. Do not modify this field!
     CanardTreeNode* root;
 
-    /// The memory resource used by this queue for allocating payload data (CAN frames).
-    /// There is exactly one allocation per enqueued item. Its size is equal to the MTU of the queue.
+    /// The memory resource used by this queue for allocating the payload data (CAN frames).
+    /// There is exactly one allocation of payload buffer per enqueued item (not considering the item itself
+    /// b/c it is allocated from different memory resource - the instance one; see CanardInstance::memory).
+    /// The size of the allocation is equal (or might be less for the last frame) to the MTU of the queue.
     /// Memory for the queue item is allocated separately from the instance memory resource.
     /// In a simple application, there would be just one memory resource shared by all parts of the library.
     /// If the application knows its MTU, it can use block allocation to avoid extrinsic fragmentation,

--- a/tests/.clang-tidy
+++ b/tests/.clang-tidy
@@ -36,7 +36,11 @@ Checks: >-
   -*-no-malloc,
   -cert-msc30-c,
   -cert-msc50-cpp,
-  -modernize-macro-to-enum,
+  -*-macro-to-enum,
+  -misc-include-cleaner,
+  -bugprone-chained-comparison,
+  -performance-avoid-endl,
+  -*-use-ranges,
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*\.hpp'
 FormatStyle: file

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This software is distributed under the terms of the MIT License.
-# Copyright (c) 2016 OpenCyphal.
+# Copyright (c) OpenCyphal.
 # Author: Pavel Kirienko <pavel@opencyphal.org>
 # Contributors: https://github.com/OpenCyphal/libcanard/contributors.
 

--- a/tests/exposed.hpp
+++ b/tests/exposed.hpp
@@ -19,17 +19,17 @@ struct TxItem final : CanardTxQueueItem
 {
     [[nodiscard]] auto getPayloadByte(const std::size_t offset) const -> std::uint8_t
     {
-        return reinterpret_cast<const std::uint8_t*>(frame.payload)[offset];
+        return static_cast<const std::uint8_t*>(frame.payload.data)[offset];
     }
 
     [[nodiscard]] auto getTailByte() const
     {
-        if (frame.payload_size < 1U)
+        if (frame.payload.size < 1U)
         {
             // Can't use REQUIRE because it is not thread-safe.
             throw std::logic_error("Can't get the tail byte because the frame payload is empty.");
         }
-        return getPayloadByte(frame.payload_size - 1U);
+        return getPayloadByte(frame.payload.size - 1U);
     }
 
     [[nodiscard]] auto isStartOfTransfer() const { return (getTailByte() & 128U) != 0; }
@@ -45,30 +45,28 @@ struct TxItem final : CanardTxQueueItem
 
 struct RxSession
 {
-    CanardMicrosecond transfer_timestamp_usec = std::numeric_limits<std::uint64_t>::max();
-    std::size_t       total_payload_size      = 0U;
-    std::size_t       payload_size            = 0U;
-    std::uint8_t*     payload                 = nullptr;
-    TransferCRC       calculated_crc          = 0U;
-    CanardTransferID  transfer_id             = std::numeric_limits<std::uint8_t>::max();
-    std::uint8_t      redundant_iface_index   = std::numeric_limits<std::uint8_t>::max();
-    bool              toggle                  = false;
+    CanardMicrosecond    transfer_timestamp_usec = std::numeric_limits<std::uint64_t>::max();
+    std::size_t          total_payload_size      = 0U;
+    CanardMutablePayload payload                 = {0U, nullptr, 0U};
+    TransferCRC          calculated_crc          = 0U;
+    CanardTransferID     transfer_id             = std::numeric_limits<std::uint8_t>::max();
+    std::uint8_t         redundant_iface_index   = std::numeric_limits<std::uint8_t>::max();
+    bool                 toggle                  = false;
 };
 
 struct RxFrameModel
 {
-    CanardMicrosecond   timestamp_usec      = std::numeric_limits<std::uint64_t>::max();
-    CanardPriority      priority            = CanardPriorityOptional;
-    CanardTransferKind  transfer_kind       = CanardTransferKindMessage;
-    CanardPortID        port_id             = std::numeric_limits<std::uint16_t>::max();
-    CanardNodeID        source_node_id      = CANARD_NODE_ID_UNSET;
-    CanardNodeID        destination_node_id = CANARD_NODE_ID_UNSET;
-    CanardTransferID    transfer_id         = std::numeric_limits<std::uint8_t>::max();
-    bool                start_of_transfer   = false;
-    bool                end_of_transfer     = false;
-    bool                toggle              = false;
-    std::size_t         payload_size        = 0U;
-    const std::uint8_t* payload             = nullptr;
+    CanardMicrosecond  timestamp_usec      = std::numeric_limits<std::uint64_t>::max();
+    CanardPriority     priority            = CanardPriorityOptional;
+    CanardTransferKind transfer_kind       = CanardTransferKindMessage;
+    CanardPortID       port_id             = std::numeric_limits<std::uint16_t>::max();
+    CanardNodeID       source_node_id      = CANARD_NODE_ID_UNSET;
+    CanardNodeID       destination_node_id = CANARD_NODE_ID_UNSET;
+    CanardTransferID   transfer_id         = std::numeric_limits<std::uint8_t>::max();
+    bool               start_of_transfer   = false;
+    bool               end_of_transfer     = false;
+    bool               toggle              = false;
+    CanardPayload      payload             = {0U, nullptr};
 };
 
 // Extern C effectively discards the outer namespaces.

--- a/tests/exposed.hpp
+++ b/tests/exposed.hpp
@@ -107,7 +107,7 @@ auto rxSessionWritePayload(CanardInstance* const ins,
                            const std::size_t     payload_size,
                            const void* const     payload) -> std::int8_t;
 
-void rxSessionRestart(CanardInstance* const ins, RxSession* const rxs);
+void rxSessionRestart(CanardInstance* const ins, RxSession* const rxs, const std::size_t allocated_size);
 
 auto rxSessionUpdate(CanardInstance* const     ins,
                      RxSession* const          rxs,

--- a/tests/exposed.hpp
+++ b/tests/exposed.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "canard.h"
-#include <cstdarg>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <stdexcept>

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -317,7 +317,7 @@ public:
         return static_cast<exposed::TxItem*>(ret);  // NOLINT static downcast
     }
 
-    [[nodiscard]] auto pop(const CanardTxQueueItem* const which) -> exposed::TxItem*
+    [[nodiscard]] auto pop(CanardTxQueueItem* const which) -> exposed::TxItem*
     {
         checkInvariants();
         const auto size_before  = que_.size;

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -296,14 +296,21 @@ public:
     [[nodiscard]] auto push(CanardInstance* const         ins,
                             const CanardMicrosecond       transmission_deadline_usec,
                             const CanardTransferMetadata& metadata,
-                            const struct CanardPayload    payload)
+                            const struct CanardPayload    payload,
+                            const CanardMicrosecond       now_usec = 0ULL)
     {
         checkInvariants();
-        const auto size_before = que_.size;
-        const auto ret         = canardTxPush(&que_, ins, transmission_deadline_usec, &metadata, payload);
-        const auto num_added   = static_cast<std::size_t>(ret);
-        enforce((ret < 0) || ((size_before + num_added) == que_.size), "Unexpected size change after push");
+
+        const auto size_before    = que_.size;
+        const auto dropped_before = que_.stats.dropped_frames;
+
+        const auto ret       = canardTxPush(&que_, ins, transmission_deadline_usec, &metadata, payload, now_usec);
+        const auto num_added = static_cast<std::size_t>(ret);
+
+        enforce((ret < 0) || ((size_before + num_added + dropped_before - que_.stats.dropped_frames) == que_.size),
+                "Unexpected size change after push");
         checkInvariants();
+
         return ret;
     }
 
@@ -341,7 +348,18 @@ public:
     [[nodiscard]] auto getSize() const
     {
         std::size_t out = 0;
-        traverse(que_.root, [&](auto* _) {
+        traverse(que_.priority_root, [&](auto* _) {
+            (void) _;
+            out++;
+        });
+        enforce(que_.size == out, "Size miscalculation");
+        return out;
+    }
+
+    [[nodiscard]] auto getDeadlineQueueSize() const
+    {
+        std::size_t out = 0;
+        traverse(que_.deadline_root, [&](auto* _) {
             (void) _;
             out++;
         });
@@ -352,7 +370,7 @@ public:
     [[nodiscard]] auto linearize() const -> std::vector<const exposed::TxItem*>
     {
         std::vector<const exposed::TxItem*> out;
-        traverse(que_.root, [&](const CanardTreeNode* const item) {
+        traverse(que_.priority_root, [&](const CanardTreeNode* const item) {
             out.push_back(reinterpret_cast<const exposed::TxItem*>(item));
         });
         enforce(out.size() == getSize(), "Internal error");
@@ -393,6 +411,7 @@ private:
     {
         enforce(que_.user_reference == this, "User reference damaged");
         enforce(que_.size == getSize(), "Size miscalculation");
+        enforce(que_.size == getDeadlineQueueSize(), "Deadline queue size miscalculation");
     }
 
     TestAllocator allocator_;

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -188,12 +188,12 @@ public:
 
     [[nodiscard]] auto makeCanardMemoryResource() -> CanardMemoryResource
     {
-        return {this, &Instance::trampolineDeallocate, &Instance::trampolineAllocate};
+        return {this, trampolineDeallocate, trampolineAllocate};
     }
 
     [[nodiscard]] auto rxAccept(const CanardMicrosecond      timestamp_usec,
                                 const CanardFrame&           frame,
-                                const uint8_t                redundant_iface_index,
+                                const std::uint8_t           redundant_iface_index,
                                 CanardRxTransfer&            out_transfer,
                                 CanardRxSubscription** const out_subscription)
     {
@@ -250,13 +250,13 @@ public:
 private:
     static auto trampolineAllocate(void* const user_reference, const std::size_t size) -> void*
     {
-        auto* p = reinterpret_cast<Instance*>(user_reference);
+        auto* p = static_cast<Instance*>(user_reference);
         return p->allocator_.allocate(size);
     }
 
     static void trampolineDeallocate(void* const user_reference, const std::size_t size, void* const pointer)
     {
-        auto* p = reinterpret_cast<Instance*>(user_reference);
+        auto* p = static_cast<Instance*>(user_reference);
         p->allocator_.deallocate(pointer, size);
     }
 
@@ -267,7 +267,15 @@ private:
 class TxQueue
 {
 public:
-    explicit TxQueue(const std::size_t capacity, const std::size_t mtu_bytes, const CanardMemoryResource memory) :
+    TxQueue(const std::size_t capacity, const std::size_t mtu_bytes) :
+        que_(canardTxInit(capacity, mtu_bytes, makeCanardMemoryResource()))
+    {
+        enforce(que_.user_reference == nullptr, "Incorrect initialization of the user reference in TxQueue");
+        enforce(que_.mtu_bytes == mtu_bytes, "Incorrect MTU");
+        que_.user_reference = this;  // This is simply to ensure it is not overwritten unexpectedly.
+        checkInvariants();
+    }
+    TxQueue(const std::size_t capacity, const std::size_t mtu_bytes, const CanardMemoryResource memory) :
         que_(canardTxInit(capacity, mtu_bytes, memory))
     {
         enforce(que_.user_reference == nullptr, "Incorrect initialization of the user reference in TxQueue");
@@ -299,14 +307,14 @@ public:
         return ret;
     }
 
-    [[nodiscard]] auto peek() const -> const exposed::TxItem*
+    [[nodiscard]] auto peek() const -> exposed::TxItem*
     {
         checkInvariants();
-        const auto        before = que_.size;
-        const auto* const ret    = canardTxPeek(&que_);
+        const auto  before = que_.size;
+        auto* const ret    = canardTxPeek(&que_);
         enforce(((ret == nullptr) ? (before == 0) : (before > 0)) && (que_.size == before), "Bad peek");
         checkInvariants();
-        return static_cast<const exposed::TxItem*>(ret);  // NOLINT static downcast
+        return static_cast<exposed::TxItem*>(ret);  // NOLINT static downcast
     }
 
     [[nodiscard]] auto pop(const CanardTxQueueItem* const which) -> exposed::TxItem*
@@ -327,6 +335,8 @@ public:
         checkInvariants();
         return static_cast<exposed::TxItem*>(out);  // NOLINT static downcast
     }
+
+    void freeItem(Instance& ins, CanardTxQueueItem* const item) { canardTxFree(&que_, &ins.getInstance(), item); }
 
     [[nodiscard]] auto getSize() const
     {
@@ -352,7 +362,25 @@ public:
     [[nodiscard]] auto getInstance() -> CanardTxQueue& { return que_; }
     [[nodiscard]] auto getInstance() const -> const CanardTxQueue& { return que_; }
 
+    [[nodiscard]] auto getAllocator() -> TestAllocator& { return allocator_; }
+    [[nodiscard]] auto makeCanardMemoryResource() -> CanardMemoryResource
+    {
+        return {this, trampolineDeallocate, trampolineAllocate};
+    }
+
 private:
+    static auto trampolineAllocate(void* const user_reference, const std::size_t size) -> void*
+    {
+        auto* p = static_cast<TxQueue*>(user_reference);
+        return p->allocator_.allocate(size);
+    }
+
+    static void trampolineDeallocate(void* const user_reference, const std::size_t size, void* const pointer)
+    {
+        auto* p = static_cast<TxQueue*>(user_reference);
+        p->allocator_.deallocate(pointer, size);
+    }
+
     static void enforce(const bool expect_true, const std::string& message)
     {
         if (!expect_true)
@@ -367,6 +395,7 @@ private:
         enforce(que_.size == getSize(), "Size miscalculation");
     }
 
+    TestAllocator allocator_;
     CanardTxQueue que_;
 };
 

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -288,12 +288,11 @@ public:
     [[nodiscard]] auto push(CanardInstance* const         ins,
                             const CanardMicrosecond       transmission_deadline_usec,
                             const CanardTransferMetadata& metadata,
-                            const std::size_t             payload_size,
-                            const void* const             payload)
+                            const struct CanardPayload    payload)
     {
         checkInvariants();
         const auto size_before = que_.size;
-        const auto ret         = canardTxPush(&que_, ins, transmission_deadline_usec, &metadata, payload_size, payload);
+        const auto ret         = canardTxPush(&que_, ins, transmission_deadline_usec, &metadata, payload);
         const auto num_added   = static_cast<std::size_t>(ret);
         enforce((ret < 0) || ((size_before + num_added) == que_.size), "Unexpected size change after push");
         checkInvariants();

--- a/tests/test_private_cavl.cpp
+++ b/tests/test_private_cavl.cpp
@@ -203,6 +203,12 @@ auto findBrokenBalanceFactor(const Node<T>* const n) -> const Cavl*  // NOLINT r
     }
     return nullptr;
 }
+
+auto getRandomByte()
+{
+    return static_cast<std::uint8_t>((0xFFLL * std::rand()) / RAND_MAX);
+}
+
 }  // namespace
 
 TEST_CASE("CheckAscension")
@@ -1265,11 +1271,6 @@ TEST_CASE("MutationManual")
     REQUIRE(nullptr == findBrokenBalanceFactor(root));
     REQUIRE(nullptr == findBrokenAncestry(root));
     REQUIRE(21 == checkAscension(root));
-}
-
-auto getRandomByte()
-{
-    return static_cast<std::uint8_t>((0xFFLL * std::rand()) / RAND_MAX);
 }
 
 TEST_CASE("MutationRandomized")

--- a/tests/test_private_rx.cpp
+++ b/tests/test_private_rx.cpp
@@ -6,6 +6,18 @@
 #include "catch.hpp"
 #include <cstring>
 
+namespace
+{
+auto bytes(const CanardPayload& payload)
+{
+    return static_cast<const std::uint8_t*>(payload.data);
+}
+auto bytes(const CanardMutablePayload& payload)
+{
+    return static_cast<std::uint8_t*>(payload.data);
+}
+}  // namespace
+
 TEST_CASE("rxTryParseFrame")
 {
     using exposed::RxFrameModel;
@@ -20,8 +32,7 @@ TEST_CASE("rxTryParseFrame")
         payload_storage = payload;
         CanardFrame frame{};
         frame.extended_can_id = extended_can_id;
-        frame.payload_size    = std::size(payload);
-        frame.payload         = payload_storage.data();
+        frame.payload         = {payload_storage.size(), payload_storage.data()};
         model                 = RxFrameModel{};
         return rxTryParseFrame(timestamp_usec, &frame, &model);
     };
@@ -38,14 +49,14 @@ TEST_CASE("rxTryParseFrame")
     REQUIRE(!model.start_of_transfer);
     REQUIRE(!model.end_of_transfer);
     REQUIRE(!model.toggle);
-    REQUIRE(model.payload_size == 7);
-    REQUIRE(model.payload[0] == 0);
-    REQUIRE(model.payload[1] == 1);
-    REQUIRE(model.payload[2] == 2);
-    REQUIRE(model.payload[3] == 3);
-    REQUIRE(model.payload[4] == 4);
-    REQUIRE(model.payload[5] == 5);
-    REQUIRE(model.payload[6] == 6);
+    REQUIRE(model.payload.size == 7);
+    REQUIRE(bytes(model.payload)[0] == 0);
+    REQUIRE(bytes(model.payload)[1] == 1);
+    REQUIRE(bytes(model.payload)[2] == 2);
+    REQUIRE(bytes(model.payload)[3] == 3);
+    REQUIRE(bytes(model.payload)[4] == 4);
+    REQUIRE(bytes(model.payload)[5] == 5);
+    REQUIRE(bytes(model.payload)[6] == 6);
     // SIMILAR BUT INVALID
     REQUIRE(!parse(543210U, 0U, {}));                     // NO TAIL BYTE
     REQUIRE(!parse(543210U, 0U, {0}));                    // MFT FRAMES REQUIRE PAYLOAD
@@ -63,14 +74,14 @@ TEST_CASE("rxTryParseFrame")
     REQUIRE(model.start_of_transfer);
     REQUIRE(!model.end_of_transfer);
     REQUIRE(model.toggle);
-    REQUIRE(model.payload_size == 7);
-    REQUIRE(model.payload[0] == 0);
-    REQUIRE(model.payload[1] == 1);
-    REQUIRE(model.payload[2] == 2);
-    REQUIRE(model.payload[3] == 3);
-    REQUIRE(model.payload[4] == 4);
-    REQUIRE(model.payload[5] == 5);
-    REQUIRE(model.payload[6] == 6);
+    REQUIRE(model.payload.size == 7);
+    REQUIRE(bytes(model.payload)[0] == 0);
+    REQUIRE(bytes(model.payload)[1] == 1);
+    REQUIRE(bytes(model.payload)[2] == 2);
+    REQUIRE(bytes(model.payload)[3] == 3);
+    REQUIRE(bytes(model.payload)[4] == 4);
+    REQUIRE(bytes(model.payload)[5] == 5);
+    REQUIRE(bytes(model.payload)[6] == 6);
     // SIMILAR BUT INVALID
     // NO TAIL BYTE
     REQUIRE(!parse(123456U, 0b001'00'0'11'0110011001100'0'0100111U, {}));
@@ -97,7 +108,7 @@ TEST_CASE("rxTryParseFrame")
     REQUIRE(model.start_of_transfer);
     REQUIRE(model.end_of_transfer);
     REQUIRE(model.toggle);
-    REQUIRE(model.payload_size == 0);
+    REQUIRE(model.payload.size == 0);
     // SAME BUT RESERVED 21 22 SET (and ignored)
     REQUIRE(parse(12345U, 0b010'01'0'11'0110011001101'0'0100111U, {0b111'00000U | 0U}));
     REQUIRE(model.port_id == 0b0110011001101U);
@@ -120,11 +131,11 @@ TEST_CASE("rxTryParseFrame")
     REQUIRE(!model.start_of_transfer);
     REQUIRE(model.end_of_transfer);
     REQUIRE(model.toggle);
-    REQUIRE(model.payload_size == 4);
-    REQUIRE(model.payload[0] == 0);
-    REQUIRE(model.payload[1] == 1);
-    REQUIRE(model.payload[2] == 2);
-    REQUIRE(model.payload[3] == 3);
+    REQUIRE(model.payload.size == 4);
+    REQUIRE(bytes(model.payload)[0] == 0);
+    REQUIRE(bytes(model.payload)[1] == 1);
+    REQUIRE(bytes(model.payload)[2] == 2);
+    REQUIRE(bytes(model.payload)[3] == 3);
     // SIMILAR BUT INVALID
     REQUIRE(!parse(999'999U, 0b011'11'0000110011'0011010'0100111U, {}));                                // NO TAIL BYTE
     REQUIRE(!parse(999'999U, 0b011'11'0000110011'0011010'0100111U, {0, 1, 2, 3, 0b110'00000U | 31U}));  // BAD TOGGLE
@@ -143,8 +154,8 @@ TEST_CASE("rxTryParseFrame")
     REQUIRE(!model.start_of_transfer);
     REQUIRE(model.end_of_transfer);
     REQUIRE(!model.toggle);
-    REQUIRE(model.payload_size == 1);
-    REQUIRE(model.payload[0] == 255);
+    REQUIRE(model.payload.size == 1);
+    REQUIRE(bytes(model.payload)[0] == 255);
     // SIMILAR BUT INVALID
     REQUIRE(!parse(888'888U, 0b100'10'0000110011'0100111'0011010U, {}));                        // NO TAIL BYTE
     REQUIRE(!parse(888'888U, 0b100'10'0000110011'0100111'0011010U, {255, 0b100'00000U | 1U}));  // BAD TOGGLE
@@ -170,70 +181,70 @@ TEST_CASE("rxSessionWritePayload")
     REQUIRE(0 == rxSessionWritePayload(&ins.getInstance(), &rxs, 10, 5, "\x00\x01\x02\x03\x04"));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 10);
-    REQUIRE(rxs.payload_size == 5);
-    REQUIRE(rxs.payload != nullptr);
-    REQUIRE(rxs.payload[0] == 0);
-    REQUIRE(rxs.payload[1] == 1);
-    REQUIRE(rxs.payload[2] == 2);
-    REQUIRE(rxs.payload[3] == 3);
-    REQUIRE(rxs.payload[4] == 4);
+    REQUIRE(rxs.payload.size == 5);
+    REQUIRE(rxs.payload.data != nullptr);
+    REQUIRE(bytes(rxs.payload)[0] == 0);
+    REQUIRE(bytes(rxs.payload)[1] == 1);
+    REQUIRE(bytes(rxs.payload)[2] == 2);
+    REQUIRE(bytes(rxs.payload)[3] == 3);
+    REQUIRE(bytes(rxs.payload)[4] == 4);
 
     // Appending the pre-allocated storage.
     REQUIRE(0 == rxSessionWritePayload(&ins.getInstance(), &rxs, 10, 4, "\x05\x06\x07\x08"));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 10);
-    REQUIRE(rxs.payload_size == 9);
-    REQUIRE(rxs.payload != nullptr);
-    REQUIRE(rxs.payload[0] == 0);
-    REQUIRE(rxs.payload[1] == 1);
-    REQUIRE(rxs.payload[2] == 2);
-    REQUIRE(rxs.payload[3] == 3);
-    REQUIRE(rxs.payload[4] == 4);
-    REQUIRE(rxs.payload[5] == 5);
-    REQUIRE(rxs.payload[6] == 6);
-    REQUIRE(rxs.payload[7] == 7);
-    REQUIRE(rxs.payload[8] == 8);
+    REQUIRE(rxs.payload.size == 9);
+    REQUIRE(rxs.payload.data != nullptr);
+    REQUIRE(bytes(rxs.payload)[0] == 0);
+    REQUIRE(bytes(rxs.payload)[1] == 1);
+    REQUIRE(bytes(rxs.payload)[2] == 2);
+    REQUIRE(bytes(rxs.payload)[3] == 3);
+    REQUIRE(bytes(rxs.payload)[4] == 4);
+    REQUIRE(bytes(rxs.payload)[5] == 5);
+    REQUIRE(bytes(rxs.payload)[6] == 6);
+    REQUIRE(bytes(rxs.payload)[7] == 7);
+    REQUIRE(bytes(rxs.payload)[8] == 8);
 
     // Implicit truncation -- too much payload, excess ignored.
     REQUIRE(0 == rxSessionWritePayload(&ins.getInstance(), &rxs, 10, 3, "\x09\x0A\x0B"));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 10);
-    REQUIRE(rxs.payload_size == 10);
-    REQUIRE(rxs.payload != nullptr);
-    REQUIRE(rxs.payload[0] == 0);
-    REQUIRE(rxs.payload[1] == 1);
-    REQUIRE(rxs.payload[2] == 2);
-    REQUIRE(rxs.payload[3] == 3);
-    REQUIRE(rxs.payload[4] == 4);
-    REQUIRE(rxs.payload[5] == 5);
-    REQUIRE(rxs.payload[6] == 6);
-    REQUIRE(rxs.payload[7] == 7);
-    REQUIRE(rxs.payload[8] == 8);
-    REQUIRE(rxs.payload[9] == 9);
+    REQUIRE(rxs.payload.size == 10);
+    REQUIRE(rxs.payload.data != nullptr);
+    REQUIRE(bytes(rxs.payload)[0] == 0);
+    REQUIRE(bytes(rxs.payload)[1] == 1);
+    REQUIRE(bytes(rxs.payload)[2] == 2);
+    REQUIRE(bytes(rxs.payload)[3] == 3);
+    REQUIRE(bytes(rxs.payload)[4] == 4);
+    REQUIRE(bytes(rxs.payload)[5] == 5);
+    REQUIRE(bytes(rxs.payload)[6] == 6);
+    REQUIRE(bytes(rxs.payload)[7] == 7);
+    REQUIRE(bytes(rxs.payload)[8] == 8);
+    REQUIRE(bytes(rxs.payload)[9] == 9);
 
     // Storage is already full, write ignored.
     REQUIRE(0 == rxSessionWritePayload(&ins.getInstance(), &rxs, 10, 3, "\x0C\x0D\x0E"));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 10);
-    REQUIRE(rxs.payload_size == 10);
-    REQUIRE(rxs.payload != nullptr);
-    REQUIRE(rxs.payload[0] == 0);
-    REQUIRE(rxs.payload[1] == 1);
-    REQUIRE(rxs.payload[2] == 2);
-    REQUIRE(rxs.payload[3] == 3);
-    REQUIRE(rxs.payload[4] == 4);
-    REQUIRE(rxs.payload[5] == 5);
-    REQUIRE(rxs.payload[6] == 6);
-    REQUIRE(rxs.payload[7] == 7);
-    REQUIRE(rxs.payload[8] == 8);
-    REQUIRE(rxs.payload[9] == 9);
+    REQUIRE(rxs.payload.size == 10);
+    REQUIRE(rxs.payload.data != nullptr);
+    REQUIRE(bytes(rxs.payload)[0] == 0);
+    REQUIRE(bytes(rxs.payload)[1] == 1);
+    REQUIRE(bytes(rxs.payload)[2] == 2);
+    REQUIRE(bytes(rxs.payload)[3] == 3);
+    REQUIRE(bytes(rxs.payload)[4] == 4);
+    REQUIRE(bytes(rxs.payload)[5] == 5);
+    REQUIRE(bytes(rxs.payload)[6] == 6);
+    REQUIRE(bytes(rxs.payload)[7] == 7);
+    REQUIRE(bytes(rxs.payload)[8] == 8);
+    REQUIRE(bytes(rxs.payload)[9] == 9);
 
     // Restart frees the buffer. The transfer-ID will be incremented, too.
     rxSessionRestart(&ins.getInstance(), &rxs, 10);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFFU);
     REQUIRE(rxs.transfer_id == 1);
     REQUIRE(rxs.toggle);
@@ -245,8 +256,8 @@ TEST_CASE("rxSessionWritePayload")
     rxSessionRestart(&ins.getInstance(), &rxs, 10);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFFU);
     REQUIRE(rxs.transfer_id == 24U);
     REQUIRE(rxs.toggle);
@@ -258,8 +269,8 @@ TEST_CASE("rxSessionWritePayload")
     rxSessionRestart(&ins.getInstance(), &rxs, 10);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFFU);
     REQUIRE(rxs.transfer_id == 0U);
     REQUIRE(rxs.toggle);
@@ -268,16 +279,16 @@ TEST_CASE("rxSessionWritePayload")
     REQUIRE(0 == rxSessionWritePayload(&ins.getInstance(), &rxs, 0, 3, "\x00\x01\x02"));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
 
     // Write with OOM.
     ins.getAllocator().setAllocationCeiling(5);
     REQUIRE(-CANARD_ERROR_OUT_OF_MEMORY == rxSessionWritePayload(&ins.getInstance(), &rxs, 10, 3, "\x00\x01\x02"));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
 }
 
 TEST_CASE("rxSessionUpdate")
@@ -302,8 +313,8 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer   = true;
     frame.end_of_transfer     = true;
     frame.toggle              = true;
-    frame.payload_size        = 3;
-    frame.payload             = reinterpret_cast<const uint8_t*>("\x01\x01\x01");
+    frame.payload.size        = 3;
+    frame.payload.data        = reinterpret_cast<const uint8_t*>("\x01\x01\x01");
 
     RxSession rxs;
     rxs.transfer_id           = 31;
@@ -327,8 +338,8 @@ TEST_CASE("rxSessionUpdate")
     // Accept one transfer.
     REQUIRE(1 == update(1, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 10'000'000);
-    REQUIRE(rxs.payload_size == 0);   // Handed over to the output transfer.
-    REQUIRE(rxs.payload == nullptr);  // Handed over to the output transfer.
+    REQUIRE(rxs.payload.size == 0);        // Handed over to the output transfer.
+    REQUIRE(rxs.payload.data == nullptr);  // Handed over to the output transfer.
     REQUIRE(rxs.calculated_crc == 0xFFFF);
     REQUIRE(rxs.transfer_id == 12U);  // Incremented.
     REQUIRE(rxs.toggle);
@@ -339,21 +350,21 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.port_id == 2'222);
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 11);
-    REQUIRE(transfer.payload_size == 3);
-    REQUIRE(transfer.allocated_size == 16);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x01\x01", 3));
+    REQUIRE(transfer.payload.size == 3);
+    REQUIRE(transfer.payload.allocated_size == 16);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x01\x01\x01", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
 
     // Valid next transfer, wrong transport.
     frame.timestamp_usec = 10'000'100;
     frame.transfer_id    = 12;
-    frame.payload        = reinterpret_cast<const uint8_t*>("\x02\x02\x02");
+    frame.payload.data   = reinterpret_cast<const uint8_t*>("\x02\x02\x02");
     REQUIRE(0 == update(2, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 10'000'000);
-    REQUIRE(rxs.payload_size == 0);   // Handed over to the output transfer.
-    REQUIRE(rxs.payload == nullptr);  // Handed over to the output transfer.
+    REQUIRE(rxs.payload.size == 0);        // Handed over to the output transfer.
+    REQUIRE(rxs.payload.data == nullptr);  // Handed over to the output transfer.
     REQUIRE(rxs.calculated_crc == 0xFFFF);
     REQUIRE(rxs.transfer_id == 12U);  // Incremented.
     REQUIRE(rxs.toggle);
@@ -361,11 +372,11 @@ TEST_CASE("rxSessionUpdate")
 
     // Correct transport.
     frame.timestamp_usec = 10'000'050;
-    frame.payload        = reinterpret_cast<const uint8_t*>("\x03\x03\x03");
+    frame.payload.data   = reinterpret_cast<const uint8_t*>("\x03\x03\x03");
     REQUIRE(1 == update(1, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 10'000'050);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFF);
     REQUIRE(rxs.transfer_id == 13U);
     REQUIRE(rxs.toggle);
@@ -376,21 +387,21 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.port_id == 2'222);
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 12);
-    REQUIRE(transfer.payload_size == 3);
-    REQUIRE(transfer.allocated_size == 16);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x03\x03\x03", 3));
+    REQUIRE(transfer.payload.size == 3);
+    REQUIRE(transfer.payload.allocated_size == 16);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x03\x03\x03", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
 
     // Same TID.
     frame.timestamp_usec = 10'000'200;
     frame.transfer_id    = 12;
-    frame.payload        = reinterpret_cast<const uint8_t*>("\x04\x04\x04");
+    frame.payload.data   = reinterpret_cast<const uint8_t*>("\x04\x04\x04");
     REQUIRE(0 == update(1, 1'000'200, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 10'000'050);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFF);
     REQUIRE(rxs.transfer_id == 13U);
     REQUIRE(rxs.toggle);
@@ -399,11 +410,11 @@ TEST_CASE("rxSessionUpdate")
     // Restart due to TID timeout, same iface.
     frame.timestamp_usec = 15'000'000;
     frame.transfer_id    = 12;
-    frame.payload        = reinterpret_cast<const uint8_t*>("\x05\x05\x05");
+    frame.payload.data   = reinterpret_cast<const uint8_t*>("\x05\x05\x05");
     REQUIRE(1 == update(1, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 15'000'000);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFF);
     REQUIRE(rxs.transfer_id == 13U);
     REQUIRE(rxs.toggle);
@@ -414,21 +425,21 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.port_id == 2'222);
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 12);
-    REQUIRE(transfer.payload_size == 3);
-    REQUIRE(transfer.allocated_size == 16);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x05\x05\x05", 3));
+    REQUIRE(transfer.payload.size == 3);
+    REQUIRE(transfer.payload.allocated_size == 16);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x05\x05\x05", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
 
     // Restart due to TID timeout, switch iface.
     frame.timestamp_usec = 20'000'000;
     frame.transfer_id    = 11;
-    frame.payload        = reinterpret_cast<const uint8_t*>("\x05\x05\x05");
+    frame.payload.data   = reinterpret_cast<const uint8_t*>("\x05\x05\x05");
     REQUIRE(1 == update(0, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'000);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFF);
     REQUIRE(rxs.transfer_id == 12U);
     REQUIRE(rxs.toggle);
@@ -439,23 +450,23 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.port_id == 2'222);
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 11);
-    REQUIRE(transfer.payload_size == 3);
-    REQUIRE(transfer.allocated_size == 16);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x05\x05\x05", 3));
+    REQUIRE(transfer.payload.size == 3);
+    REQUIRE(transfer.payload.allocated_size == 16);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x05\x05\x05", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
 
     // Multi-frame, first.
     frame.timestamp_usec  = 20'000'100;
     frame.transfer_id     = 13;
     frame.end_of_transfer = false;
-    frame.payload_size    = 7;
-    frame.payload         = reinterpret_cast<const uint8_t*>("\x06\x06\x06\x06\x06\x06\x06");
+    frame.payload.size    = 7;
+    frame.payload.data    = reinterpret_cast<const uint8_t*>("\x06\x06\x06\x06\x06\x06\x06");
     REQUIRE(0 == update(0, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'100);
-    REQUIRE(rxs.payload_size == 7);
-    REQUIRE(0 == std::memcmp(rxs.payload, "\x06\x06\x06\x06\x06\x06\x06", 7));
+    REQUIRE(rxs.payload.size == 7);
+    REQUIRE(0 == std::memcmp(rxs.payload.data, "\x06\x06\x06\x06\x06\x06\x06", 7));
     REQUIRE(rxs.calculated_crc == crc("\x06\x06\x06\x06\x06\x06\x06"));
     REQUIRE(rxs.transfer_id == 13U);
     REQUIRE(!rxs.toggle);
@@ -468,11 +479,11 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = false;
     frame.end_of_transfer   = false;
     frame.toggle            = false;
-    frame.payload           = reinterpret_cast<const uint8_t*>("\x07\x07\x07\x07\x07\x07\x07");
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\x07\x07\x07\x07\x07\x07\x07");
     REQUIRE(0 == update(0, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'100);
-    REQUIRE(rxs.payload_size == 14);
-    REQUIRE(0 == std::memcmp(rxs.payload, "\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07", 14));
+    REQUIRE(rxs.payload.size == 14);
+    REQUIRE(0 == std::memcmp(rxs.payload.data, "\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07", 14));
     REQUIRE(rxs.calculated_crc == crc("\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07"));
     REQUIRE(rxs.transfer_id == 13U);
     REQUIRE(rxs.toggle);
@@ -485,11 +496,11 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = false;
     frame.end_of_transfer   = true;
     frame.toggle            = false;
-    frame.payload           = reinterpret_cast<const uint8_t*>("\x08\x08\x08\x08");
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\x08\x08\x08\x08");
     REQUIRE(0 == update(0, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'100);
-    REQUIRE(rxs.payload_size == 14);
-    REQUIRE(0 == std::memcmp(rxs.payload, "\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07", 14));
+    REQUIRE(rxs.payload.size == 14);
+    REQUIRE(0 == std::memcmp(rxs.payload.data, "\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07", 14));
     REQUIRE(rxs.calculated_crc == crc("\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07"));
     REQUIRE(rxs.transfer_id == 13U);
     REQUIRE(rxs.toggle);
@@ -502,12 +513,12 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = false;
     frame.end_of_transfer   = true;
     frame.toggle            = true;
-    frame.payload_size      = 6;  // The payload is IMPLICITLY TRUNCATED, and the CRC IS STILL VALIDATED.
-    frame.payload           = reinterpret_cast<const uint8_t*>("\x09\x09\x09\x09\r\x93");
+    frame.payload.size      = 6;  // The payload is IMPLICITLY TRUNCATED, and the CRC IS STILL VALIDATED.
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\x09\x09\x09\x09\r\x93");
     REQUIRE(1 == update(0, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'100);  // First frame.
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFF);
     REQUIRE(rxs.transfer_id == 14U);
     REQUIRE(rxs.toggle);
@@ -518,12 +529,13 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.port_id == 2'222);
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 13);
-    REQUIRE(transfer.payload_size == 16);
-    REQUIRE(transfer.allocated_size == 16);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07\x09\x09", 16));
+    REQUIRE(transfer.payload.size == 16);
+    REQUIRE(transfer.payload.allocated_size == 16);
+    REQUIRE(0 ==
+            std::memcmp(transfer.payload.data, "\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07\x09\x09", 16));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
 
     // TID timeout does not occur until SOT; see https://github.com/OpenCyphal/libcanard/issues/212.
     frame.timestamp_usec    = 30'000'000;
@@ -531,8 +543,8 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = false;
     frame.end_of_transfer   = false;
     frame.toggle            = true;
-    frame.payload_size      = 7;
-    frame.payload           = reinterpret_cast<const uint8_t*>("\x0A\x0A\x0A\x0A\x0A\x0A\x0A");
+    frame.payload.size      = 7;
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\x0A\x0A\x0A\x0A\x0A\x0A\x0A");
     REQUIRE(0 == update(2, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'100);  // No change.
     REQUIRE(rxs.transfer_id == 14U);                     // No change.
@@ -547,12 +559,12 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = true;
     frame.end_of_transfer   = false;
     frame.toggle            = true;
-    frame.payload_size      = 7;
-    frame.payload           = reinterpret_cast<const uint8_t*>("\x0A\x0A\x0A\x0A\x0A\x0A\x0A");
+    frame.payload.size      = 7;
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\x0A\x0A\x0A\x0A\x0A\x0A\x0A");
     REQUIRE(0 == update(2, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 30'000'000);  // Updated from the frame.
-    REQUIRE(rxs.payload_size == 7);                      // From the frame.
-    REQUIRE(rxs.payload != nullptr);
+    REQUIRE(rxs.payload.size == 7);                      // From the frame.
+    REQUIRE(rxs.payload.data != nullptr);
     REQUIRE(rxs.calculated_crc == 0x23C7);
     REQUIRE(rxs.transfer_id == 12U);          // Updated from the frame.
     REQUIRE(!rxs.toggle);                     // In anticipation of the next frame.
@@ -566,12 +578,12 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = true;
     frame.end_of_transfer   = false;
     frame.toggle            = true;
-    frame.payload_size      = 7;
-    frame.payload           = reinterpret_cast<const uint8_t*>("\x0B\x0B\x0B\x0B\x0B\x0B\x0B");
+    frame.payload.size      = 7;
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\x0B\x0B\x0B\x0B\x0B\x0B\x0B");
     REQUIRE(0 == update(2, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'200);
-    REQUIRE(rxs.payload_size == 7);
-    REQUIRE(0 == std::memcmp(rxs.payload, "\x0B\x0B\x0B\x0B\x0B\x0B\x0B", 7));
+    REQUIRE(rxs.payload.size == 7);
+    REQUIRE(0 == std::memcmp(rxs.payload.data, "\x0B\x0B\x0B\x0B\x0B\x0B\x0B", 7));
     REQUIRE(rxs.calculated_crc == crc("\x0B\x0B\x0B\x0B\x0B\x0B\x0B"));
     REQUIRE(rxs.transfer_id == 10U);
     REQUIRE(!rxs.toggle);
@@ -585,12 +597,12 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = true;
     frame.end_of_transfer   = true;
     frame.toggle            = true;
-    frame.payload_size      = 7;
-    frame.payload           = reinterpret_cast<const uint8_t*>("\x0C\x0C\x0C\x0C\x0C\x0C\x0C");
+    frame.payload.size      = 7;
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\x0C\x0C\x0C\x0C\x0C\x0C\x0C");
     REQUIRE(0 == update(2, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'200);
-    REQUIRE(rxs.payload_size == 7);
-    REQUIRE(0 == std::memcmp(rxs.payload, "\x0B\x0B\x0B\x0B\x0B\x0B\x0B", 7));
+    REQUIRE(rxs.payload.size == 7);
+    REQUIRE(0 == std::memcmp(rxs.payload.data, "\x0B\x0B\x0B\x0B\x0B\x0B\x0B", 7));
     REQUIRE(rxs.calculated_crc == crc("\x0B\x0B\x0B\x0B\x0B\x0B\x0B"));
     REQUIRE(rxs.transfer_id == 10U);
     REQUIRE(!rxs.toggle);
@@ -604,12 +616,12 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = false;
     frame.end_of_transfer   = true;
     frame.toggle            = false;
-    frame.payload_size      = 5;
-    frame.payload           = reinterpret_cast<const uint8_t*>("\x0D\x0D\x0DWd");  // CRC at the end.
+    frame.payload.size      = 5;
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\x0D\x0D\x0DWd");  // CRC at the end.
     REQUIRE(1 == update(2, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'200);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFF);
     REQUIRE(rxs.transfer_id == 11U);
     REQUIRE(rxs.toggle);
@@ -620,12 +632,12 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.port_id == 2'222);
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 10);
-    REQUIRE(transfer.payload_size == 10);
-    REQUIRE(transfer.allocated_size == 16);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0D\x0D\x0D", 10));
+    REQUIRE(transfer.payload.size == 10);
+    REQUIRE(transfer.payload.allocated_size == 16);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0D\x0D\x0D", 10));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
 
     // CRC SPLIT -- first frame.
     frame.timestamp_usec    = 30'000'000;
@@ -633,12 +645,12 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = true;
     frame.end_of_transfer   = false;
     frame.toggle            = true;
-    frame.payload_size      = 8;
-    frame.payload           = reinterpret_cast<const uint8_t*>("\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7");
+    frame.payload.size      = 8;
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7");
     REQUIRE(0 == update(0, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 30'000'000);
-    REQUIRE(rxs.payload_size == 8);
-    REQUIRE(0 == std::memcmp(rxs.payload, "\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7", 8));
+    REQUIRE(rxs.payload.size == 8);
+    REQUIRE(0 == std::memcmp(rxs.payload.data, "\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7", 8));
     REQUIRE(rxs.calculated_crc == crc("\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7"));
     REQUIRE(rxs.transfer_id == 0);
     REQUIRE(!rxs.toggle);
@@ -652,12 +664,12 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = false;
     frame.end_of_transfer   = true;
     frame.toggle            = false;
-    frame.payload_size      = 1;
-    frame.payload           = reinterpret_cast<const uint8_t*>("\xD7");
+    frame.payload.size      = 1;
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\xD7");
     REQUIRE(1 == update(0, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 30'000'000);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFF);
     REQUIRE(rxs.transfer_id == 1U);
     REQUIRE(rxs.toggle);
@@ -668,12 +680,12 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.port_id == 2'222);
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 0);
-    REQUIRE(transfer.payload_size == 7);  // ONE CRC BYTE BACKTRACKED!
-    REQUIRE(transfer.allocated_size == 16);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x0E\x0E\x0E\x0E\x0E\x0E\x0E", 7));
+    REQUIRE(transfer.payload.size == 7);  // ONE CRC BYTE BACKTRACKED!
+    REQUIRE(transfer.payload.allocated_size == 16);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x0E\x0E\x0E\x0E\x0E\x0E\x0E", 7));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
 
     // BAD CRC -- first frame.
     frame.timestamp_usec    = 30'001'000;
@@ -681,12 +693,12 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = true;
     frame.end_of_transfer   = false;
     frame.toggle            = true;
-    frame.payload_size      = 8;
-    frame.payload           = reinterpret_cast<const uint8_t*>("\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7");
+    frame.payload.size      = 8;
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7");
     REQUIRE(0 == update(0, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 30'001'000);
-    REQUIRE(rxs.payload_size == 8);
-    REQUIRE(0 == std::memcmp(rxs.payload, "\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7", 8));
+    REQUIRE(rxs.payload.size == 8);
+    REQUIRE(0 == std::memcmp(rxs.payload.data, "\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7", 8));
     REQUIRE(rxs.calculated_crc == crc("\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7"));
     REQUIRE(rxs.transfer_id == 31U);
     REQUIRE(!rxs.toggle);
@@ -700,12 +712,12 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = false;
     frame.end_of_transfer   = true;
     frame.toggle            = false;
-    frame.payload_size      = 1;
-    frame.payload           = reinterpret_cast<const uint8_t*>("\xD8");
+    frame.payload.size      = 1;
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\xD8");
     REQUIRE(0 == update(0, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 30'001'000);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFF);
     REQUIRE(rxs.transfer_id == 0U);
     REQUIRE(rxs.toggle);
@@ -719,12 +731,12 @@ TEST_CASE("rxSessionUpdate")
     frame.start_of_transfer = true;
     frame.end_of_transfer   = false;
     frame.toggle            = true;
-    frame.payload_size      = 8;
-    frame.payload           = reinterpret_cast<const uint8_t*>("\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7");
+    frame.payload.size      = 8;
+    frame.payload.data      = reinterpret_cast<const uint8_t*>("\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7");
     REQUIRE((-CANARD_ERROR_OUT_OF_MEMORY) == update(2, 1'000'000, 17));  // Exceeds the heap quota.
     REQUIRE(rxs.transfer_timestamp_usec == 40'000'000);
-    REQUIRE(rxs.payload_size == 0);
-    REQUIRE(rxs.payload == nullptr);
+    REQUIRE(rxs.payload.size == 0);
+    REQUIRE(rxs.payload.data == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFF);
     REQUIRE(rxs.transfer_id == 31U);  // Reset.
     REQUIRE(rxs.toggle);

--- a/tests/test_private_rx.cpp
+++ b/tests/test_private_rx.cpp
@@ -229,7 +229,7 @@ TEST_CASE("rxSessionWritePayload")
     REQUIRE(rxs.payload[9] == 9);
 
     // Restart frees the buffer. The transfer-ID will be incremented, too.
-    rxSessionRestart(&ins.getInstance(), &rxs);
+    rxSessionRestart(&ins.getInstance(), &rxs, 10);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
     REQUIRE(rxs.payload_size == 0);
@@ -242,7 +242,7 @@ TEST_CASE("rxSessionWritePayload")
     rxs.calculated_crc = 0x1234U;
     rxs.transfer_id    = 23;
     rxs.toggle         = false;
-    rxSessionRestart(&ins.getInstance(), &rxs);
+    rxSessionRestart(&ins.getInstance(), &rxs, 10);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
     REQUIRE(rxs.payload_size == 0);
@@ -255,7 +255,7 @@ TEST_CASE("rxSessionWritePayload")
     rxs.calculated_crc = 0x1234U;
     rxs.transfer_id    = 31;
     rxs.toggle         = false;
-    rxSessionRestart(&ins.getInstance(), &rxs);
+    rxSessionRestart(&ins.getInstance(), &rxs, 10);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
     REQUIRE(rxs.payload_size == 0);
@@ -340,10 +340,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 11);
     REQUIRE(transfer.payload_size == 3);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x01\x01", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // Valid next transfer, wrong transport.
     frame.timestamp_usec = 10'000'100;
@@ -376,10 +377,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 12);
     REQUIRE(transfer.payload_size == 3);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x03\x03\x03", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // Same TID.
     frame.timestamp_usec = 10'000'200;
@@ -413,10 +415,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 12);
     REQUIRE(transfer.payload_size == 3);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x05\x05\x05", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // Restart due to TID timeout, switch iface.
     frame.timestamp_usec = 20'000'000;
@@ -437,10 +440,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 11);
     REQUIRE(transfer.payload_size == 3);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x05\x05\x05", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // Multi-frame, first.
     frame.timestamp_usec  = 20'000'100;
@@ -515,10 +519,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 13);
     REQUIRE(transfer.payload_size == 16);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07\x09\x09", 16));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // TID timeout does not occur until SOT; see https://github.com/OpenCyphal/libcanard/issues/212.
     frame.timestamp_usec    = 30'000'000;
@@ -616,10 +621,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 10);
     REQUIRE(transfer.payload_size == 10);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0D\x0D\x0D", 10));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // CRC SPLIT -- first frame.
     frame.timestamp_usec    = 30'000'000;
@@ -663,10 +669,11 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 0);
     REQUIRE(transfer.payload_size == 7);  // ONE CRC BYTE BACKTRACKED!
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x0E\x0E\x0E\x0E\x0E\x0E\x0E", 7));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
 
     // BAD CRC -- first frame.
     frame.timestamp_usec    = 30'001'000;

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -191,9 +191,10 @@ TEST_CASE("RoundtripSimple")
                     else
                     {
                         REQUIRE(transfer.payload_size == 0U);
+                        REQUIRE(transfer.allocated_size == 0U);
                     }
 
-                    ins_rx.getAllocator().deallocate(transfer.payload);
+                    ins_rx.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
                     std::free(ref_payload);  // NOLINT
                 }
                 else
@@ -212,7 +213,7 @@ TEST_CASE("RoundtripSimple")
 
             {
                 const std::lock_guard locker(lock);
-                ins_tx.getAllocator().deallocate(ti);
+                ins_tx.getAllocator().deallocate(ti, (ti != nullptr) ? ti->allocated_size : 0);
             }
 
             if (std::chrono::steady_clock::now() > deadline)

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -11,9 +11,11 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <unordered_map>
+#include <utility>
 
 TEST_CASE("RoundtripSimple")
 {
@@ -32,9 +34,7 @@ TEST_CASE("RoundtripSimple")
     helpers::Instance ins_rx;
     ins_rx.setNodeID(111);
 
-    const auto get_random_priority = []() {
-        return static_cast<CanardPriority>(getRandomNatural(CANARD_PRIORITY_MAX + 1U));
-    };
+    const auto get_random_priority = []() { return getRandomNatural<CanardPriority>(CANARD_PRIORITY_MAX + 1U); };
     std::array<TxState, 6> tx_states{
         TxState{CanardTransferKindMessage, get_random_priority(), 8191, 1000},
         TxState{CanardTransferKindMessage, get_random_priority(), 511, 0},
@@ -57,11 +57,12 @@ TEST_CASE("RoundtripSimple")
     ins_rx.getAllocator().setAllocationCeiling(rx_worst_case_memory_consumption);  // This is guaranteed to be enough.
 
     helpers::Instance ins_tx;
-    helpers::TxQueue  que_tx(1024UL * 1024U * 1024U, CANARD_MTU_CAN_FD);
+    helpers::TxQueue  que_tx(1024UL * 1024U * 1024U, CANARD_MTU_CAN_FD, ins_tx.makeCanardMemoryResource());
     ins_tx.setNodeID(99);
     ins_tx.getAllocator().setAllocationCeiling(1024UL * 1024U * 1024U);
 
-    using Pending = std::tuple<CanardTransferMetadata, std::size_t, void*>;
+    using PayloadPtr = std::unique_ptr<std::uint8_t[]>;  // NOLINT
+    using Pending    = std::tuple<CanardTransferMetadata, std::size_t, PayloadPtr>;
     std::unordered_map<CanardMicrosecond, Pending> pending_transfers;
 
     std::atomic<CanardMicrosecond> transfer_counter      = 0;
@@ -74,12 +75,12 @@ TEST_CASE("RoundtripSimple")
     const auto writer_thread_fun = [&]() {
         while (keep_going)
         {
-            auto& st = tx_states.at(getRandomNatural(std::size(tx_states)));
+            auto& st = tx_states.at(getRandomNatural<std::size_t>(std::size(tx_states)));
 
             // Generate random payload. The size may be larger than expected to test the implicit truncation rule.
-            const auto  payload_size = getRandomNatural(st.extent + 1024U);
-            auto* const payload      = static_cast<std::uint8_t*>(std::malloc(payload_size));  // NOLINT
-            std::generate_n(payload, payload_size, [&]() { return static_cast<std::uint8_t>(getRandomNatural(256U)); });
+            const auto payload_size = getRandomNatural<std::size_t>(st.extent + 1024U);
+            PayloadPtr payload{new std::uint8_t[payload_size]};
+            std::generate_n(payload.get(), payload_size, [&]() { return getRandomNatural<std::uint8_t>(256U); });
 
             // Generate the transfer.
             const CanardMicrosecond timestamp_usec = transfer_counter++;
@@ -92,16 +93,17 @@ TEST_CASE("RoundtripSimple")
             tran.transfer_id = (st.transfer_id++) & CANARD_TRANSFER_ID_MAX;
 
             // Use a random MTU.
-            que_tx.setMTU(static_cast<std::uint8_t>(getRandomNatural(256U)));
+            que_tx.setMTU(getRandomNatural<std::size_t>(256U));
 
             // Push the transfer.
             bool sleep = false;
             {
                 const std::lock_guard locker(lock);
-                const auto result = que_tx.push(&ins_tx.getInstance(), timestamp_usec, tran, payload_size, payload);
+                const auto            result =
+                    que_tx.push(&ins_tx.getInstance(), timestamp_usec, tran, payload_size, payload.get());
                 if (result > 0)
                 {
-                    pending_transfers.emplace(timestamp_usec, Pending{tran, payload_size, payload});
+                    pending_transfers.emplace(timestamp_usec, Pending{tran, payload_size, std::move(payload)});
                     frames_in_flight += static_cast<std::uint64_t>(result);
                     peak_frames_in_flight = std::max<std::uint64_t>(peak_frames_in_flight, frames_in_flight);
                 }
@@ -171,10 +173,10 @@ TEST_CASE("RoundtripSimple")
                         const std::lock_guard locker(lock);
                         const auto            pt_it = pending_transfers.find(transfer.timestamp_usec);
                         REQUIRE(pt_it != pending_transfers.end());
-                        reference = pt_it->second;
+                        reference = std::move(pt_it->second);
                         pending_transfers.erase(pt_it);
                     }
-                    const auto [ref_meta, ref_payload_size, ref_payload] = reference;
+                    const auto [ref_meta, ref_payload_size, ref_payload] = std::move(reference);
 
                     REQUIRE(transfer.metadata.priority == ref_meta.priority);
                     REQUIRE(transfer.metadata.transfer_kind == ref_meta.transfer_kind);
@@ -185,7 +187,7 @@ TEST_CASE("RoundtripSimple")
                     if (transfer.payload != nullptr)
                     {
                         REQUIRE(0 == std::memcmp(transfer.payload,
-                                                 ref_payload,
+                                                 ref_payload.get(),
                                                  std::min(transfer.payload_size, ref_payload_size)));
                     }
                     else
@@ -195,7 +197,6 @@ TEST_CASE("RoundtripSimple")
                     }
 
                     ins_rx.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
-                    std::free(ref_payload);  // NOLINT
                 }
                 else
                 {
@@ -238,9 +239,9 @@ TEST_CASE("RoundtripSimple")
     std::cout << "PEAK FRAMES IN FLIGHT: " << peak_frames_in_flight << std::endl;
 
     std::size_t i = 0;
-    for (const auto& [k, v] : pending_transfers)
+    for (auto& [k, v] : pending_transfers)
     {
-        const auto [ref_meta, ref_payload_size, ref_payload] = v;
+        const auto [ref_meta, ref_payload_size, ref_payload] = std::move(v);
         std::cout << "#" << i++ << "/" << std::size(pending_transfers) << ":"        //
                   << " ts=" << k                                                     //
                   << " prio=" << static_cast<std::uint16_t>(ref_meta.priority)       //

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -4,16 +4,22 @@
 #include "helpers.hpp"
 #include "exposed.hpp"
 #include "catch.hpp"
+
+#include <canard.h>
+
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <memory>
 #include <mutex>
 #include <thread>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 
@@ -160,9 +166,10 @@ TEST_CASE("RoundtripSimple")
 
                 CanardRxTransfer      transfer{};
                 CanardRxSubscription* subscription = nullptr;
-                const std::int8_t result = ins_rx.rxAccept(ti->tx_deadline_usec, ti->frame, 0, transfer, &subscription);
+                const CanardFrame frame = {ti->frame.extended_can_id, {ti->frame.payload.size, ti->frame.payload.data}};
+                const std::int8_t result = ins_rx.rxAccept(ti->tx_deadline_usec, frame, 0, transfer, &subscription);
                 REQUIRE(0 == ins_rx.rxAccept(ti->tx_deadline_usec,
-                                             ti->frame,
+                                             frame,
                                              1,
                                              transfer,
                                              &subscription));  // Redundant interface will never be used here.
@@ -214,7 +221,7 @@ TEST_CASE("RoundtripSimple")
 
             {
                 const std::lock_guard locker(lock);
-                ins_tx.getAllocator().deallocate(ti, (ti != nullptr) ? ti->allocated_size : 0);
+                que_tx.freeItem(ins_tx, ti);
             }
 
             if (std::chrono::steady_clock::now() > deadline)

--- a/tests/test_public_rx.cpp
+++ b/tests/test_public_rx.cpp
@@ -118,11 +118,16 @@ TEST_CASE("RxBasic0")
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 0);
     REQUIRE(transfer.payload_size == 0);
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "", 0));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 16));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    auto* msg_payload = transfer.payload;  // Will need it later.
+
+    // Will need these later.
+    //
+    auto* const msg_payload        = transfer.payload;
+    const auto  payload_alloc_size = transfer.allocated_size;
 
     // Provide the space for an extra session and its payload.
     ins.getAllocator().setAllocationCeiling(sizeof(RxSession) * 2 + 16 + 20);
@@ -150,6 +155,7 @@ TEST_CASE("RxBasic0")
     REQUIRE(transfer.metadata.remote_node_id == 0b0100101);
     REQUIRE(transfer.metadata.transfer_id == 4);
     REQUIRE(transfer.payload_size == 3);
+    REQUIRE(transfer.allocated_size == 20);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);  // Two SESSIONS and two PAYLOAD BUFFERS.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 16 + 20));
@@ -188,7 +194,7 @@ TEST_CASE("RxBasic0")
     REQUIRE(nullptr == ins.rxGetSubscription(CanardTransferKindMessage, 0b0110011001100));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 16 + 20));
-    ins.getAllocator().deallocate(msg_payload);
+    ins.getAllocator().deallocate(msg_payload, payload_alloc_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 3);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 20));
 
@@ -204,6 +210,7 @@ TEST_CASE("RxBasic0")
     REQUIRE(transfer.metadata.remote_node_id == 0b0011011);
     REQUIRE(transfer.metadata.transfer_id == 3);
     REQUIRE(transfer.payload_size == 1);
+    REQUIRE(transfer.allocated_size == 10);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x05", 1));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 10 + 20));
@@ -298,6 +305,7 @@ TEST_CASE("RxAnonymous")
     REQUIRE(transfer.metadata.remote_node_id == CANARD_NODE_ID_UNSET);
     REQUIRE(transfer.metadata.transfer_id == 0);
     REQUIRE(transfer.payload_size == 16);  // Truncated.
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10", 0));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The PAYLOAD BUFFER only! No session for anons.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
@@ -315,13 +323,14 @@ TEST_CASE("RxAnonymous")
     REQUIRE(transfer.metadata.remote_node_id == CANARD_NODE_ID_UNSET);
     REQUIRE(transfer.metadata.transfer_id == 0);
     REQUIRE(transfer.payload_size == 16);  // Truncated.
+    REQUIRE(transfer.allocated_size == 16);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10", 0));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The PAYLOAD BUFFER only! No session for anons.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
     REQUIRE(ensureAllNullptr(ins.getMessageSubs().at(0)->sessions));  // No RX states!
 
     // Release the memory.
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
 
@@ -336,7 +345,8 @@ TEST_CASE("RxAnonymous")
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == CANARD_NODE_ID_UNSET);
     REQUIRE(transfer.metadata.transfer_id == 0);
-    REQUIRE(transfer.payload_size == 6);  // NOT truncated.
+    REQUIRE(transfer.payload_size == 6);    // NOT truncated.
+    REQUIRE(transfer.allocated_size == 6);  // Less than extent b/c it's anonymous single frame transfer.
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06", 0));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);      // The PAYLOAD BUFFER only! No session for anons.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 6);       // Smaller allocation.
@@ -436,11 +446,12 @@ TEST_CASE("Issue189")  // https://github.com/OpenCyphal/libcanard/issues/189
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 0);
     REQUIRE(transfer.payload_size == 1);
+    REQUIRE(transfer.allocated_size == 50);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x42", 1));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 
@@ -484,6 +495,7 @@ TEST_CASE("Issue189")  // https://github.com/OpenCyphal/libcanard/issues/189
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 2);
     REQUIRE(transfer.payload_size == 11);
+    REQUIRE(transfer.allocated_size == 50);
     REQUIRE(0 == std::memcmp(transfer.payload,
                              "\x01\x02\x03\x04\x05\x06\x07"
                              "DUCK",
@@ -491,7 +503,7 @@ TEST_CASE("Issue189")  // https://github.com/OpenCyphal/libcanard/issues/189
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 }
@@ -561,11 +573,12 @@ TEST_CASE("Issue212")
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 2);
     REQUIRE(transfer.payload_size == 14);
+    REQUIRE(transfer.allocated_size == 50);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E", 14));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 
@@ -595,11 +608,12 @@ TEST_CASE("Issue212")
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 3);
     REQUIRE(transfer.payload_size == 14);
+    REQUIRE(transfer.allocated_size == 50);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E", 14));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 }
@@ -664,11 +678,12 @@ TEST_CASE("RxFixedTIDWithSmallTimeout")
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 0);
     REQUIRE(transfer.payload_size == 14);
+    REQUIRE(transfer.allocated_size == 50);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E", 14));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 
@@ -688,11 +703,12 @@ TEST_CASE("RxFixedTIDWithSmallTimeout")
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 0);  // same
     REQUIRE(transfer.payload_size == 8);
+    REQUIRE(transfer.allocated_size == 50);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07\x08", 8));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 
@@ -709,11 +725,12 @@ TEST_CASE("RxFixedTIDWithSmallTimeout")
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 0);  // same
     REQUIRE(transfer.payload_size == 7);
+    REQUIRE(transfer.allocated_size == 50);
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07", 7));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload);
+    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 }

--- a/tests/test_public_rx.cpp
+++ b/tests/test_public_rx.cpp
@@ -30,8 +30,7 @@ TEST_CASE("RxBasic0")
         payload_storage = payload;
         CanardFrame frame{};
         frame.extended_can_id = extended_can_id;
-        frame.payload_size    = std::size(payload);
-        frame.payload         = payload_storage.data();
+        frame.payload         = {std::size(payload), payload_storage.data()};
         return ins.rxAccept(timestamp_usec, frame, redundant_iface_index, transfer, &subscription);
     };
 
@@ -117,17 +116,17 @@ TEST_CASE("RxBasic0")
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 0);
-    REQUIRE(transfer.payload_size == 0);
-    REQUIRE(transfer.allocated_size == 16);
-    REQUIRE(0 == std::memcmp(transfer.payload, "", 0));
+    REQUIRE(transfer.payload.size == 0);
+    REQUIRE(transfer.payload.allocated_size == 16);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "", 0));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 16));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
 
     // Will need these later.
     //
-    auto* const msg_payload        = transfer.payload;
-    const auto  payload_alloc_size = transfer.allocated_size;
+    auto* const msg_payload        = transfer.payload.data;
+    const auto  payload_alloc_size = transfer.payload.allocated_size;
 
     // Provide the space for an extra session and its payload.
     ins.getAllocator().setAllocationCeiling(sizeof(RxSession) * 2 + 16 + 20);
@@ -154,9 +153,9 @@ TEST_CASE("RxBasic0")
     REQUIRE(transfer.metadata.port_id == 0b0000110011);
     REQUIRE(transfer.metadata.remote_node_id == 0b0100101);
     REQUIRE(transfer.metadata.transfer_id == 4);
-    REQUIRE(transfer.payload_size == 3);
-    REQUIRE(transfer.allocated_size == 20);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03", 3));
+    REQUIRE(transfer.payload.size == 3);
+    REQUIRE(transfer.payload.allocated_size == 20);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x01\x02\x03", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);  // Two SESSIONS and two PAYLOAD BUFFERS.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 16 + 20));
     REQUIRE(ins.getRequestSubs().at(0)->sessions[0b0100101] != nullptr);
@@ -209,9 +208,9 @@ TEST_CASE("RxBasic0")
     REQUIRE(transfer.metadata.port_id == 0b0000111100);
     REQUIRE(transfer.metadata.remote_node_id == 0b0011011);
     REQUIRE(transfer.metadata.transfer_id == 3);
-    REQUIRE(transfer.payload_size == 1);
-    REQUIRE(transfer.allocated_size == 10);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x05", 1));
+    REQUIRE(transfer.payload.size == 1);
+    REQUIRE(transfer.payload.allocated_size == 10);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x05", 1));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 10 + 20));
 
@@ -268,8 +267,7 @@ TEST_CASE("RxAnonymous")
         payload_storage = payload;
         CanardFrame frame{};
         frame.extended_can_id = extended_can_id;
-        frame.payload_size    = std::size(payload);
-        frame.payload         = payload_storage.data();
+        frame.payload         = {std::size(payload), payload_storage.data()};
         return ins.rxAccept(timestamp_usec, frame, redundant_iface_index, transfer, &subscription);
     };
 
@@ -304,9 +302,10 @@ TEST_CASE("RxAnonymous")
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == CANARD_NODE_ID_UNSET);
     REQUIRE(transfer.metadata.transfer_id == 0);
-    REQUIRE(transfer.payload_size == 16);  // Truncated.
-    REQUIRE(transfer.allocated_size == 16);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10", 0));
+    REQUIRE(transfer.payload.size == 16);  // Truncated.
+    REQUIRE(transfer.payload.allocated_size == 16);
+    REQUIRE(0 ==
+            std::memcmp(transfer.payload.data, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10", 0));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The PAYLOAD BUFFER only! No session for anons.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
     REQUIRE(ensureAllNullptr(ins.getMessageSubs().at(0)->sessions));  // No RX states!
@@ -322,15 +321,16 @@ TEST_CASE("RxAnonymous")
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == CANARD_NODE_ID_UNSET);
     REQUIRE(transfer.metadata.transfer_id == 0);
-    REQUIRE(transfer.payload_size == 16);  // Truncated.
-    REQUIRE(transfer.allocated_size == 16);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10", 0));
+    REQUIRE(transfer.payload.size == 16);  // Truncated.
+    REQUIRE(transfer.payload.allocated_size == 16);
+    REQUIRE(0 ==
+            std::memcmp(transfer.payload.data, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10", 0));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The PAYLOAD BUFFER only! No session for anons.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
     REQUIRE(ensureAllNullptr(ins.getMessageSubs().at(0)->sessions));  // No RX states!
 
     // Release the memory.
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
 
@@ -345,9 +345,9 @@ TEST_CASE("RxAnonymous")
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == CANARD_NODE_ID_UNSET);
     REQUIRE(transfer.metadata.transfer_id == 0);
-    REQUIRE(transfer.payload_size == 6);    // NOT truncated.
-    REQUIRE(transfer.allocated_size == 6);  // Less than extent b/c it's anonymous single frame transfer.
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06", 0));
+    REQUIRE(transfer.payload.size == 6);            // NOT truncated.
+    REQUIRE(transfer.payload.allocated_size == 6);  // Less than extent b/c it's anonymous single frame transfer.
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x01\x02\x03\x04\x05\x06", 0));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);      // The PAYLOAD BUFFER only! No session for anons.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 6);       // Smaller allocation.
     REQUIRE(ensureAllNullptr(ins.getMessageSubs().at(0)->sessions));  // No RX states!
@@ -387,7 +387,7 @@ TEST_CASE("RxSubscriptionErrors")
     REQUIRE(fake_ptr == &fake_sub);
 
     CanardFrame frame{};
-    frame.payload_size = 1U;
+    frame.payload.size = 1U;
     CanardRxTransfer transfer{};
     REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardRxAccept(&ins.getInstance(), 0, &frame, 0, &transfer, nullptr));
     REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardRxAccept(nullptr, 0, &frame, 0, &transfer, nullptr));
@@ -413,8 +413,7 @@ TEST_CASE("Issue189")  // https://github.com/OpenCyphal/libcanard/issues/189
         payload_storage = payload;
         CanardFrame frame{};
         frame.extended_can_id = extended_can_id;
-        frame.payload_size    = std::size(payload);
-        frame.payload         = payload_storage.data();
+        frame.payload         = {std::size(payload), payload_storage.data()};
         return ins.rxAccept(timestamp_usec, frame, redundant_iface_index, transfer, &subscription);
     };
 
@@ -445,13 +444,13 @@ TEST_CASE("Issue189")  // https://github.com/OpenCyphal/libcanard/issues/189
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 0);
-    REQUIRE(transfer.payload_size == 1);
-    REQUIRE(transfer.allocated_size == 50);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x42", 1));
+    REQUIRE(transfer.payload.size == 1);
+    REQUIRE(transfer.payload.allocated_size == 50);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x42", 1));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 
@@ -494,16 +493,16 @@ TEST_CASE("Issue189")  // https://github.com/OpenCyphal/libcanard/issues/189
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 2);
-    REQUIRE(transfer.payload_size == 11);
-    REQUIRE(transfer.allocated_size == 50);
-    REQUIRE(0 == std::memcmp(transfer.payload,
+    REQUIRE(transfer.payload.size == 11);
+    REQUIRE(transfer.payload.allocated_size == 50);
+    REQUIRE(0 == std::memcmp(transfer.payload.data,
                              "\x01\x02\x03\x04\x05\x06\x07"
                              "DUCK",
                              11));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 }
@@ -525,8 +524,7 @@ TEST_CASE("Issue212")
         payload_storage = payload;
         CanardFrame frame{};
         frame.extended_can_id = extended_can_id;
-        frame.payload_size    = std::size(payload);
-        frame.payload         = payload_storage.data();
+        frame.payload         = {std::size(payload), payload_storage.data()};
         return ins.rxAccept(timestamp_usec, frame, redundant_iface_index, transfer, &subscription);
     };
 
@@ -572,13 +570,13 @@ TEST_CASE("Issue212")
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 2);
-    REQUIRE(transfer.payload_size == 14);
-    REQUIRE(transfer.allocated_size == 50);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E", 14));
+    REQUIRE(transfer.payload.size == 14);
+    REQUIRE(transfer.payload.allocated_size == 50);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E", 14));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 
@@ -607,13 +605,13 @@ TEST_CASE("Issue212")
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 3);
-    REQUIRE(transfer.payload_size == 14);
-    REQUIRE(transfer.allocated_size == 50);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E", 14));
+    REQUIRE(transfer.payload.size == 14);
+    REQUIRE(transfer.payload.allocated_size == 50);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E", 14));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 }
@@ -634,8 +632,7 @@ TEST_CASE("RxFixedTIDWithSmallTimeout")
         payload_storage = payload;
         CanardFrame frame{};
         frame.extended_can_id = extended_can_id;
-        frame.payload_size    = std::size(payload);
-        frame.payload         = payload_storage.data();
+        frame.payload         = {std::size(payload), payload_storage.data()};
         return ins.rxAccept(timestamp_usec, frame, 0, transfer, &subscription);
     };
 
@@ -677,13 +674,13 @@ TEST_CASE("RxFixedTIDWithSmallTimeout")
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 0);
-    REQUIRE(transfer.payload_size == 14);
-    REQUIRE(transfer.allocated_size == 50);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E", 14));
+    REQUIRE(transfer.payload.size == 14);
+    REQUIRE(transfer.payload.allocated_size == 50);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E", 14));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 
@@ -702,13 +699,13 @@ TEST_CASE("RxFixedTIDWithSmallTimeout")
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 0);  // same
-    REQUIRE(transfer.payload_size == 8);
-    REQUIRE(transfer.allocated_size == 50);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07\x08", 8));
+    REQUIRE(transfer.payload.size == 8);
+    REQUIRE(transfer.payload.allocated_size == 50);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x01\x02\x03\x04\x05\x06\x07\x08", 8));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 
@@ -724,13 +721,13 @@ TEST_CASE("RxFixedTIDWithSmallTimeout")
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 0);  // same
-    REQUIRE(transfer.payload_size == 7);
-    REQUIRE(transfer.allocated_size == 50);
-    REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x04\x05\x06\x07", 7));
+    REQUIRE(transfer.payload.size == 7);
+    REQUIRE(transfer.payload.allocated_size == 50);
+    REQUIRE(0 == std::memcmp(transfer.payload.data, "\x01\x02\x03\x04\x05\x06\x07", 7));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 50));
     REQUIRE(ins.getMessageSubs().at(0)->sessions[0b0100111] != nullptr);
-    ins.getAllocator().deallocate(transfer.payload, transfer.allocated_size);
+    ins.getAllocator().deallocate(transfer.payload.data, transfer.payload.allocated_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);  // The payload buffer is gone.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == sizeof(RxSession));
 }

--- a/tests/test_public_rx.cpp
+++ b/tests/test_public_rx.cpp
@@ -129,7 +129,7 @@ TEST_CASE("RxBasic0")
     const auto  payload_alloc_size = transfer.payload.allocated_size;
 
     // Provide the space for an extra session and its payload.
-    ins.getAllocator().setAllocationCeiling(sizeof(RxSession) * 2 + 16 + 20);
+    ins.getAllocator().setAllocationCeiling((sizeof(RxSession) * 2) + 16 + 20);
 
     // Dropped request because the local node does not have a node-ID.
     subscription = nullptr;
@@ -157,7 +157,7 @@ TEST_CASE("RxBasic0")
     REQUIRE(transfer.payload.allocated_size == 20);
     REQUIRE(0 == std::memcmp(transfer.payload.data, "\x01\x02\x03", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);  // Two SESSIONS and two PAYLOAD BUFFERS.
-    REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 16 + 20));
+    REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == ((2 * sizeof(RxSession)) + 16 + 20));
     REQUIRE(ins.getRequestSubs().at(0)->sessions[0b0100101] != nullptr);
 
     // Response transfer not accepted because the local node has a different node-ID.
@@ -172,16 +172,16 @@ TEST_CASE("RxBasic0")
             accept(0, 100'000'003, 0b100'10'0000111100'0011010'0011011, {5, 0b111'00001}));
     REQUIRE(subscription != nullptr);  // Subscription get assigned before error code
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);
-    REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 16 + 20));
+    REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == ((2 * sizeof(RxSession)) + 16 + 20));
 
     // Response transfer not accepted due to OOM -- can't allocate the buffer (RX session is allocated OK).
-    ins.getAllocator().setAllocationCeiling(3 * sizeof(RxSession) + 16 + 20);
+    ins.getAllocator().setAllocationCeiling((3 * sizeof(RxSession)) + 16 + 20);
     subscription = nullptr;
     REQUIRE(-CANARD_ERROR_OUT_OF_MEMORY ==
             accept(0, 100'000'003, 0b100'10'0000111100'0011010'0011011, {5, 0b111'00010}));
     REQUIRE(subscription != nullptr);  // Subscription get assigned before error code
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 5);
-    REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (3 * sizeof(RxSession) + 16 + 20));
+    REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == ((3 * sizeof(RxSession)) + 16 + 20));
 
     // Destroy the message subscription and the buffer to free up memory.
     REQUIRE(1 == ins.rxHasSubscription(CanardTransferKindMessage, 0b0110011001100));
@@ -192,10 +192,10 @@ TEST_CASE("RxBasic0")
     REQUIRE(0 == ins.rxHasSubscription(CanardTransferKindMessage, 0b0110011001100));
     REQUIRE(nullptr == ins.rxGetSubscription(CanardTransferKindMessage, 0b0110011001100));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);
-    REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 16 + 20));
+    REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == ((2 * sizeof(RxSession)) + 16 + 20));
     ins.getAllocator().deallocate(msg_payload, payload_alloc_size);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 3);
-    REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 20));
+    REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == ((2 * sizeof(RxSession)) + 20));
 
     // Same response accepted now. We have to keep incrementing the transfer-ID though because it's tracked.
     subscription = nullptr;
@@ -212,7 +212,7 @@ TEST_CASE("RxBasic0")
     REQUIRE(transfer.payload.allocated_size == 10);
     REQUIRE(0 == std::memcmp(transfer.payload.data, "\x05", 1));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);
-    REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 10 + 20));
+    REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == ((2 * sizeof(RxSession)) + 10 + 20));
 
     // Bad frames shall be rejected silently.
     subscription = nullptr;

--- a/tests/test_public_tx.cpp
+++ b/tests/test_public_tx.cpp
@@ -5,8 +5,6 @@
 #include "helpers.hpp"
 #include "catch.hpp"
 
-#include <canard.h>
-
 #include <array>
 #include <cstddef>
 #include <cstdint>

--- a/tests/test_public_tx.cpp
+++ b/tests/test_public_tx.cpp
@@ -127,8 +127,8 @@ TEST_CASE("TxBasic0")
 
     // Pop the queue.
     // hex(pycyphal.transport.commons.crc.CRC16CCITT.new(list(range(8))).value)
-    constexpr std::uint16_t  CRC8 = 0x178DU;
-    const CanardTxQueueItem* ti   = que.peek();
+    constexpr std::uint16_t CRC8 = 0x178DU;
+    CanardTxQueueItem*      ti   = que.peek();
     REQUIRE(nullptr != ti);
     REQUIRE(ti->frame.payload.size == 12);
     REQUIRE(0 == std::memcmp(ti->frame.payload.data, payload.data(), 8));
@@ -453,8 +453,8 @@ TEST_CASE("TxBasic1")
 
     // Pop the queue.
     // hex(pycyphal.transport.commons.crc.CRC16CCITT.new(list(range(8))).value)
-    constexpr std::uint16_t  CRC8 = 0x178DU;
-    const CanardTxQueueItem* ti   = que.peek();
+    constexpr std::uint16_t CRC8 = 0x178DU;
+    CanardTxQueueItem*      ti   = que.peek();
     REQUIRE(nullptr != ti);
     REQUIRE(ti->frame.payload.size == 12);
     REQUIRE(0 == std::memcmp(ti->frame.payload.data, payload.data(), 8));

--- a/tests/test_public_tx.cpp
+++ b/tests/test_public_tx.cpp
@@ -30,7 +30,7 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
-    alloc.setAllocationCeiling(400);
+    alloc.setAllocationCeiling(496);
 
     CanardTransferMetadata meta{};
 
@@ -72,7 +72,7 @@ TEST_CASE("TxBasic0")
     REQUIRE(3 == que.getSize());
     REQUIRE(6 == alloc.getNumAllocatedFragments());
     REQUIRE(20 < alloc.getTotalAllocatedAmount());
-    REQUIRE(400 > alloc.getTotalAllocatedAmount());
+    REQUIRE(496 > alloc.getTotalAllocatedAmount());
 
     // Check the TX queue.
     {
@@ -123,7 +123,7 @@ TEST_CASE("TxBasic0")
     REQUIRE(3 == que.getSize());
     REQUIRE(6 == alloc.getNumAllocatedFragments());
     REQUIRE(20 < alloc.getTotalAllocatedAmount());
-    REQUIRE(400 > alloc.getTotalAllocatedAmount());
+    REQUIRE(496 > alloc.getTotalAllocatedAmount());
 
     // Pop the queue.
     // hex(pycyphal.transport.commons.crc.CRC16CCITT.new(list(range(8))).value)
@@ -190,7 +190,7 @@ TEST_CASE("TxBasic0")
     REQUIRE(3 == que.getSize());
     REQUIRE(6 == alloc.getNumAllocatedFragments());
     REQUIRE(40 < alloc.getTotalAllocatedAmount());
-    REQUIRE(400 > alloc.getTotalAllocatedAmount());
+    REQUIRE(496 > alloc.getTotalAllocatedAmount());
     // Read the generated frames.
     ti = que.peek();
     REQUIRE(nullptr != ti);
@@ -235,7 +235,7 @@ TEST_CASE("TxBasic0")
     REQUIRE(3 == que.getSize());
     REQUIRE(6 == alloc.getNumAllocatedFragments());
     REQUIRE(40 < alloc.getTotalAllocatedAmount());
-    REQUIRE(400 > alloc.getTotalAllocatedAmount());
+    REQUIRE(496 > alloc.getTotalAllocatedAmount());
     // Read the generated frames.
     ti = que.peek();
     REQUIRE(nullptr != ti);
@@ -341,11 +341,11 @@ TEST_CASE("TxBasic0")
     REQUIRE(nullptr == ti);
 
     // Error handling.
-    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardTxPush(nullptr, nullptr, 0, nullptr, {0, nullptr}));
-    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardTxPush(nullptr, nullptr, 0, &meta, {0, nullptr}));
-    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardTxPush(nullptr, &ins.getInstance(), 0, &meta, {0, nullptr}));
+    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardTxPush(nullptr, nullptr, 0, nullptr, {0, nullptr}, 0));
+    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardTxPush(nullptr, nullptr, 0, &meta, {0, nullptr}, 0));
+    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardTxPush(nullptr, &ins.getInstance(), 0, &meta, {0, nullptr}, 0));
     REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT ==
-            canardTxPush(&que.getInstance(), &ins.getInstance(), 0, nullptr, {0, nullptr}));
+            canardTxPush(&que.getInstance(), &ins.getInstance(), 0, nullptr, {0, nullptr}, 0));
     REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == que.push(&ins.getInstance(), 1'000'000'006'000ULL, meta, {1, nullptr}));
 
     REQUIRE(nullptr == canardTxPeek(nullptr));
@@ -408,7 +408,7 @@ TEST_CASE("TxBasic1")
     REQUIRE(3 == que.getSize());
     REQUIRE(6 == alloc.getNumAllocatedFragments());
     REQUIRE(20 < alloc.getTotalAllocatedAmount());
-    REQUIRE(400 > alloc.getTotalAllocatedAmount());
+    REQUIRE(496 > alloc.getTotalAllocatedAmount());
 
     // Check the TX queue.
     {
@@ -449,7 +449,7 @@ TEST_CASE("TxBasic1")
     REQUIRE(3 == que.getSize());
     REQUIRE(6 == alloc.getNumAllocatedFragments());
     REQUIRE(20 < alloc.getTotalAllocatedAmount());
-    REQUIRE(400 > alloc.getTotalAllocatedAmount());
+    REQUIRE(496 > alloc.getTotalAllocatedAmount());
 
     // Pop the queue.
     // hex(pycyphal.transport.commons.crc.CRC16CCITT.new(list(range(8))).value)
@@ -514,7 +514,7 @@ TEST_CASE("TxBasic1")
     REQUIRE(3 == que.getSize());
     REQUIRE(6 == alloc.getNumAllocatedFragments());
     REQUIRE(40 < alloc.getTotalAllocatedAmount());
-    REQUIRE(400 > alloc.getTotalAllocatedAmount());
+    REQUIRE(496 > alloc.getTotalAllocatedAmount());
     // Read the generated frames.
     ti = que.peek();
     REQUIRE(nullptr != ti);
@@ -559,7 +559,7 @@ TEST_CASE("TxBasic1")
     REQUIRE(3 == que.getSize());
     REQUIRE(6 == alloc.getNumAllocatedFragments());
     REQUIRE(40 < alloc.getTotalAllocatedAmount());
-    REQUIRE(400 > alloc.getTotalAllocatedAmount());
+    REQUIRE(496 > alloc.getTotalAllocatedAmount());
     // Read the generated frames.
     ti = que.peek();
     REQUIRE(nullptr != ti);
@@ -665,11 +665,11 @@ TEST_CASE("TxBasic1")
     REQUIRE(nullptr == ti);
 
     // Error handling.
-    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardTxPush(nullptr, nullptr, 0, nullptr, {0, nullptr}));
-    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardTxPush(nullptr, nullptr, 0, &meta, {0, nullptr}));
-    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardTxPush(nullptr, &ins.getInstance(), 0, &meta, {0, nullptr}));
+    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardTxPush(nullptr, nullptr, 0, nullptr, {0, nullptr}, 0));
+    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardTxPush(nullptr, nullptr, 0, &meta, {0, nullptr}, 0));
+    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == canardTxPush(nullptr, &ins.getInstance(), 0, &meta, {0, nullptr}, 0));
     REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT ==
-            canardTxPush(&que.getInstance(), &ins.getInstance(), 0, nullptr, {0, nullptr}));
+            canardTxPush(&que.getInstance(), &ins.getInstance(), 0, nullptr, {0, nullptr}, 0));
     REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT == que.push(&ins.getInstance(), 1'000'000'006'000ULL, meta, {1, nullptr}));
 
     REQUIRE(nullptr == canardTxPeek(nullptr));
@@ -812,5 +812,121 @@ TEST_CASE("TxPayloadOwnership")
             REQUIRE(0 == ins_alloc.getNumAllocatedFragments());
             REQUIRE(sizeof(CanardTxQueueItem) * 0 == ins_alloc.getTotalAllocatedAmount());
         }
+    }
+}
+
+TEST_CASE("TxFlushExpired")
+{
+    helpers::Instance ins;
+    helpers::TxQueue  que{2, CANARD_MTU_CAN_FD};  // Limit capacity at 2 frames.
+
+    auto& tx_alloc  = que.getAllocator();
+    auto& ins_alloc = ins.getAllocator();
+
+    std::array<std::uint8_t, 1024> payload{};
+    std::iota(payload.begin(), payload.end(), 0U);
+
+    REQUIRE(CANARD_NODE_ID_UNSET == ins.getNodeID());
+    REQUIRE(CANARD_MTU_CAN_FD == que.getMTU());
+    REQUIRE(0 == que.getSize());
+    REQUIRE(0 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(0 == ins_alloc.getNumAllocatedFragments());
+
+    CanardMicrosecond       now      = 10'000'000ULL;  // 10s
+    const CanardMicrosecond deadline = 1'000'000ULL;   // 1s
+
+    CanardTransferMetadata meta{};
+
+    // 1. Push single-frame with padding, peek. @ 10s
+    {
+        meta.priority       = CanardPriorityNominal;
+        meta.transfer_kind  = CanardTransferKindMessage;
+        meta.port_id        = 321;
+        meta.remote_node_id = CANARD_NODE_ID_UNSET;
+        meta.transfer_id    = 21;
+        REQUIRE(1 == que.push(&ins.getInstance(), now + deadline, meta, {8, payload.data()}, now));
+        REQUIRE(1 == que.getSize());
+        REQUIRE(1 == tx_alloc.getNumAllocatedFragments());
+        REQUIRE((8 + 4) == tx_alloc.getTotalAllocatedAmount());
+        REQUIRE(1 == ins_alloc.getNumAllocatedFragments());
+        REQUIRE(sizeof(CanardTxQueueItem) * 1 == ins_alloc.getTotalAllocatedAmount());
+
+        // Peek and check the payload.
+        CanardTxQueueItem* ti = que.peek();
+        REQUIRE(nullptr != ti);  // Make sure we get the same frame again.
+        REQUIRE(ti->frame.payload.size == 12);
+        REQUIRE(ti->frame.payload.allocated_size == 12);
+        REQUIRE(0 == std::memcmp(ti->frame.payload.data, payload.data(), 8));
+        REQUIRE(ti->tx_deadline_usec == now + deadline);
+        REQUIRE(1 == tx_alloc.getNumAllocatedFragments());
+        REQUIRE((8 + 4) == tx_alloc.getTotalAllocatedAmount());
+        REQUIRE(1 == ins_alloc.getNumAllocatedFragments());
+        REQUIRE(sizeof(CanardTxQueueItem) * 1 == ins_alloc.getTotalAllocatedAmount());
+
+        // Don't pop and free the item - we gonna flush it by the next push at 12s.
+    }
+
+    now += 2 * deadline;  // 10s -> 12s
+
+    // 2. Push two-frames, peek. @ 12s (after 2x deadline)
+    //    These 2 frames should still fit into the queue (with capacity 2) despite one expired frame still there.`
+    {
+        que.setMTU(8);
+        ins.setNodeID(42);
+        meta.transfer_id = 22;
+        REQUIRE(2 == que.push(&ins.getInstance(), now + deadline, meta, {8, payload.data()}, now));
+        REQUIRE(2 == que.getSize());
+        REQUIRE(2 == tx_alloc.getNumAllocatedFragments());
+        REQUIRE((8 + 4) == tx_alloc.getTotalAllocatedAmount());
+        REQUIRE(2 == ins_alloc.getNumAllocatedFragments());
+        REQUIRE(sizeof(CanardTxQueueItem) * 2 == ins_alloc.getTotalAllocatedAmount());
+        REQUIRE(1 == que.getInstance().stats.dropped_frames);
+
+        // a) Peek and check the payload of the 1st frame
+        CanardTxQueueItem* ti = nullptr;
+        {
+            ti = que.peek();
+            REQUIRE(nullptr != ti);
+            REQUIRE(ti->frame.payload.size == 8);
+            REQUIRE(ti->frame.payload.allocated_size == 8);
+            REQUIRE(0 == std::memcmp(ti->frame.payload.data, payload.data(), 7));
+            REQUIRE(ti->tx_deadline_usec == now + deadline);
+            REQUIRE(2 == tx_alloc.getNumAllocatedFragments());
+            REQUIRE((8 + 4) == tx_alloc.getTotalAllocatedAmount());
+            REQUIRE(2 == ins_alloc.getNumAllocatedFragments());
+            REQUIRE(sizeof(CanardTxQueueItem) * 2 == ins_alloc.getTotalAllocatedAmount());
+
+            // Don't pop and free the item - we gonna flush it by the next push @ 14s.
+        }
+        // b) Check the payload of the 2nd frame
+        {
+            ti = ti->next_in_transfer;
+            REQUIRE(nullptr != ti);
+            REQUIRE(ti->frame.payload.size == 4);
+            REQUIRE(ti->frame.payload.allocated_size == 4);
+            REQUIRE(0 == std::memcmp(ti->frame.payload.data, payload.data() + 7, 1));
+            REQUIRE(ti->tx_deadline_usec == now + deadline);
+
+            // Don't pop and free the item - we gonna flush it by the next push @ 14s.
+        }
+    }
+
+    now += 2 * deadline;  // 12s -> 14s
+
+    // 3. Push three-frames, peek. @ 14s (after another 2x deadline)
+    //    These 3 frames should not fit into the queue (with capacity 2),
+    //    but as a side effect, the expired frames (from push @ 12s) should be flushed as well.
+    {
+        meta.transfer_id = 23;
+        REQUIRE(-CANARD_ERROR_OUT_OF_MEMORY ==
+                que.push(&ins.getInstance(), now + deadline, meta, {8ULL * 2ULL, payload.data()}, now));
+        REQUIRE(0 == que.getSize());
+        REQUIRE(0 == tx_alloc.getNumAllocatedFragments());
+        REQUIRE(0 == tx_alloc.getTotalAllocatedAmount());
+        REQUIRE(0 == ins_alloc.getNumAllocatedFragments());
+        REQUIRE(0 == ins_alloc.getTotalAllocatedAmount());
+        REQUIRE(1 + 2 == que.getInstance().stats.dropped_frames);
+
+        REQUIRE(nullptr == que.peek());
     }
 }

--- a/tests/test_public_tx.cpp
+++ b/tests/test_public_tx.cpp
@@ -129,7 +129,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 8));
     REQUIRE((0b11100000U | 21U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[11]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'000'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    auto* item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(2 == que.getSize());
     REQUIRE(2 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -138,7 +139,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 7));
     REQUIRE((0b10100000U | 22U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[7]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'000'100ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -149,7 +151,8 @@ TEST_CASE("TxBasic0")
     REQUIRE((CRC8 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[2]);
     REQUIRE((0b01000000U | 22U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[3]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'000'100ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -181,7 +184,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 31));
     REQUIRE((0b10100000U | 25U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'001'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(2 == que.getSize());
     REQUIRE(2 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -191,7 +195,8 @@ TEST_CASE("TxBasic0")
     REQUIRE((CRC61 >> 8U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[30]);
     REQUIRE((0b00000000U | 25U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'001'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -200,7 +205,8 @@ TEST_CASE("TxBasic0")
     REQUIRE((CRC61 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[0]);
     REQUIRE((0b01100000U | 25U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[1]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'001'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -223,7 +229,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 31));
     REQUIRE((0b10100000U | 26U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'002'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(2 == que.getSize());
     REQUIRE(2 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -232,7 +239,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data() + 31U, 31));
     REQUIRE((0b00000000U | 26U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'002'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -242,7 +250,8 @@ TEST_CASE("TxBasic0")
     REQUIRE((CRC62 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[1]);
     REQUIRE((0b01100000U | 26U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[2]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'002'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -263,7 +272,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 63));
     REQUIRE((0b10100000U | 27U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[63]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'003'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -277,7 +287,8 @@ TEST_CASE("TxBasic0")
     REQUIRE((CRC112Padding12 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[62]);  // CRC
     REQUIRE((0b01000000U | 27U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[63]);        // Tail
     REQUIRE(ti->tx_deadline_usec == 1'000'000'003'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -297,7 +308,8 @@ TEST_CASE("TxBasic0")
     REQUIRE(ti->frame.payload_size == 1);
     REQUIRE((0b11100000U | 28U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[0]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'004'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -444,7 +456,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 8));
     REQUIRE((0b11100000U | 21U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[11]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'000'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    auto* item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(2 == que.getSize());
     REQUIRE(2 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -453,7 +466,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 7));
     REQUIRE((0b10100000U | 22U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[7]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'000'100ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -464,7 +478,8 @@ TEST_CASE("TxBasic1")
     REQUIRE((CRC8 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[2]);
     REQUIRE((0b01000000U | 22U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[3]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'000'100ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -494,7 +509,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 31));
     REQUIRE((0b10100000U | 25U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'001'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(2 == que.getSize());
     REQUIRE(2 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -504,7 +520,8 @@ TEST_CASE("TxBasic1")
     REQUIRE((CRC61 >> 8U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[30]);
     REQUIRE((0b00000000U | 25U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'001'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -513,7 +530,8 @@ TEST_CASE("TxBasic1")
     REQUIRE((CRC61 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[0]);
     REQUIRE((0b01100000U | 25U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[1]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'001'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -536,7 +554,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 31));
     REQUIRE((0b10100000U | 26U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'002'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(2 == que.getSize());
     REQUIRE(2 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -545,7 +564,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data() + 31U, 31));
     REQUIRE((0b00000000U | 26U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[31]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'002'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -555,7 +575,8 @@ TEST_CASE("TxBasic1")
     REQUIRE((CRC62 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[1]);
     REQUIRE((0b01100000U | 26U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[2]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'002'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -576,7 +597,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(0 == std::memcmp(ti->frame.payload, payload.data(), 63));
     REQUIRE((0b10100000U | 27U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[63]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'003'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(1 == que.getSize());
     REQUIRE(1 == alloc.getNumAllocatedFragments());
     ti = que.peek();
@@ -590,7 +612,8 @@ TEST_CASE("TxBasic1")
     REQUIRE((CRC112Padding12 & 0xFFU) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[62]);  // CRC
     REQUIRE((0b01000000U | 27U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[63]);        // Tail
     REQUIRE(ti->tx_deadline_usec == 1'000'000'003'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 
@@ -610,7 +633,8 @@ TEST_CASE("TxBasic1")
     REQUIRE(ti->frame.payload_size == 1);
     REQUIRE((0b11100000U | 28U) == reinterpret_cast<const std::uint8_t*>(ti->frame.payload)[0]);
     REQUIRE(ti->tx_deadline_usec == 1'000'000'004'000ULL);
-    ins.getAllocator().deallocate(que.pop(ti));
+    item = que.pop(ti);
+    ins.getAllocator().deallocate(item, item->allocated_size);
     REQUIRE(0 == que.getSize());
     REQUIRE(0 == alloc.getNumAllocatedFragments());
 

--- a/tests/test_public_tx.cpp
+++ b/tests/test_public_tx.cpp
@@ -11,7 +11,7 @@ TEST_CASE("TxBasic0")
     using exposed::TxItem;
 
     helpers::Instance ins;
-    helpers::TxQueue  que(200, CANARD_MTU_CAN_FD);
+    helpers::TxQueue  que(200, CANARD_MTU_CAN_FD, ins.makeCanardMemoryResource());
 
     auto& alloc = ins.getAllocator();
 
@@ -342,7 +342,7 @@ TEST_CASE("TxBasic0")
 TEST_CASE("TxBasic1")
 {
     helpers::Instance ins;
-    helpers::TxQueue  que(3, CANARD_MTU_CAN_FD);  // Limit capacity at 3 frames.
+    helpers::TxQueue  que(3, CANARD_MTU_CAN_FD, ins.makeCanardMemoryResource());  // Limit capacity at 3 frames.
 
     auto& alloc = ins.getAllocator();
 

--- a/tests/test_public_tx.cpp
+++ b/tests/test_public_tx.cpp
@@ -815,7 +815,7 @@ TEST_CASE("TxPayloadOwnership")
     }
 }
 
-TEST_CASE("TxFlushExpired")
+TEST_CASE("TxPushFlushExpired")
 {
     helpers::Instance ins;
     helpers::TxQueue  que{2, CANARD_MTU_CAN_FD};  // Limit capacity at 2 frames.
@@ -929,4 +929,334 @@ TEST_CASE("TxFlushExpired")
 
         REQUIRE(nullptr == que.peek());
     }
+}
+
+TEST_CASE("TxPollSingleFrame")
+{
+    helpers::Instance ins;
+    helpers::TxQueue  que{2, CANARD_MTU_CAN_FD};  // Limit capacity at 2 frames.
+
+    que.setMTU(8);
+    ins.setNodeID(42);
+
+    auto& tx_alloc  = que.getAllocator();
+    auto& ins_alloc = ins.getAllocator();
+
+    std::array<std::uint8_t, 1024> payload{};
+    std::iota(payload.begin(), payload.end(), 0U);
+
+    REQUIRE(42 == ins.getNodeID());
+    REQUIRE(CANARD_MTU_CAN_CLASSIC == que.getMTU());
+    REQUIRE(0 == que.getSize());
+    REQUIRE(0 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(0 == ins_alloc.getNumAllocatedFragments());
+
+    CanardMicrosecond           now      = 10'000'000ULL;  // 10s
+    constexpr CanardMicrosecond deadline = 1'000'000ULL;   // 1s
+
+    CanardTransferMetadata meta{};
+
+    // 1. Push single frame @ 10s
+    //
+    meta.priority       = CanardPriorityNominal;
+    meta.transfer_kind  = CanardTransferKindMessage;
+    meta.port_id        = 321;
+    meta.remote_node_id = CANARD_NODE_ID_UNSET;
+    meta.transfer_id    = 21;
+    REQUIRE(1 == que.push(&ins.getInstance(), now + deadline, meta, {7, payload.data()}, now));
+    REQUIRE(1 == que.getSize());
+    REQUIRE(1 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(8 == tx_alloc.getTotalAllocatedAmount());
+    REQUIRE(1 == ins_alloc.getNumAllocatedFragments());
+    REQUIRE(sizeof(CanardTxQueueItem) * 1 == ins_alloc.getTotalAllocatedAmount());
+
+    // 2. Poll with invalid arguments.
+    //
+    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT ==  // null queue
+            canardTxPoll(nullptr, &ins.getInstance(), 0, nullptr, [](auto*, auto, auto*) -> std::int8_t { return 0; }));
+    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT ==  // null instance
+            canardTxPoll(&que.getInstance(), nullptr, 0, nullptr, [](auto*, auto, auto*) -> std::int8_t { return 0; }));
+    REQUIRE(-CANARD_ERROR_INVALID_ARGUMENT ==  // null handler
+            canardTxPoll(&que.getInstance(), &ins.getInstance(), 0, nullptr, nullptr));
+
+    // 3. Poll; emulate media is busy @ 10s + 100us
+    //
+    std::size_t total_handler_calls = 0;
+    REQUIRE(0 == que.poll(ins, now + 100, [&](auto deadline_usec, auto& frame) -> std::int8_t {
+        //
+        ++total_handler_calls;
+        REQUIRE(deadline_usec == now + deadline);
+        REQUIRE(frame.payload.size == 8);
+        REQUIRE(frame.payload.allocated_size == 8);
+        REQUIRE(0 == std::memcmp(frame.payload.data, payload.data(), 7));
+        return 0;  // Emulate that TX media is busy.
+    }));
+    REQUIRE(1 == total_handler_calls);
+    REQUIRE(1 == que.getSize());
+    REQUIRE(1 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(8 == tx_alloc.getTotalAllocatedAmount());
+    REQUIRE(1 == ins_alloc.getNumAllocatedFragments());
+    REQUIRE(sizeof(CanardTxQueueItem) * 1 == ins_alloc.getTotalAllocatedAmount());
+    REQUIRE(0 == que.getInstance().stats.dropped_frames);
+
+    // 4. Poll; emulate media is ready @ 10s + 200us
+    //
+    REQUIRE(1 == que.poll(ins, now + 200, [&](auto deadline_usec, auto& frame) -> std::int8_t {
+        //
+        ++total_handler_calls;
+        REQUIRE(deadline_usec == now + deadline);
+        REQUIRE(frame.payload.size == 8);
+        REQUIRE(frame.payload.allocated_size == 8);
+        REQUIRE(0 == std::memcmp(frame.payload.data, payload.data(), 7));
+        return 1;  // Emulate that TX media accepted the frame.
+    }));
+    REQUIRE(2 == total_handler_calls);
+    REQUIRE(0 == que.getSize());
+    REQUIRE(0 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(0 == tx_alloc.getTotalAllocatedAmount());
+    REQUIRE(0 == ins_alloc.getNumAllocatedFragments());
+    REQUIRE(sizeof(CanardTxQueueItem) * 0 == ins_alloc.getTotalAllocatedAmount());
+    REQUIRE(0 == que.getInstance().stats.dropped_frames);
+
+    // 3. Poll when queue is empty @ 10s + 300us
+    //
+    REQUIRE(0 == que.poll(ins, now + 300, [&](auto, auto&) -> std::int8_t {
+        //
+        ++total_handler_calls;
+        FAIL("This should not be called.");
+        return -1;
+    }));
+    REQUIRE(2 == total_handler_calls);
+    REQUIRE(0 == que.getSize());
+}
+
+TEST_CASE("TxPollMultiFrame")
+{
+    helpers::Instance ins;
+    helpers::TxQueue  que{2, CANARD_MTU_CAN_FD};  // Limit capacity at 2 frames.
+
+    que.setMTU(8);
+    ins.setNodeID(42);
+
+    auto& tx_alloc  = que.getAllocator();
+    auto& ins_alloc = ins.getAllocator();
+
+    std::array<std::uint8_t, 1024> payload{};
+    std::iota(payload.begin(), payload.end(), 0U);
+
+    REQUIRE(42 == ins.getNodeID());
+    REQUIRE(CANARD_MTU_CAN_CLASSIC == que.getMTU());
+    REQUIRE(0 == que.getSize());
+    REQUIRE(0 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(0 == ins_alloc.getNumAllocatedFragments());
+
+    CanardMicrosecond           now      = 10'000'000ULL;  // 10s
+    constexpr CanardMicrosecond deadline = 1'000'000ULL;   // 1s
+
+    CanardTransferMetadata meta{};
+
+    // 1. Push two frames @ 10s
+    //
+    meta.priority       = CanardPriorityNominal;
+    meta.transfer_kind  = CanardTransferKindMessage;
+    meta.port_id        = 321;
+    meta.remote_node_id = CANARD_NODE_ID_UNSET;
+    meta.transfer_id    = 21;
+    REQUIRE(2 == que.push(&ins.getInstance(), now + deadline, meta, {8, payload.data()}, now));
+    REQUIRE(2 == que.getSize());
+    REQUIRE(2 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(8 + 4 == tx_alloc.getTotalAllocatedAmount());
+    REQUIRE(2 == ins_alloc.getNumAllocatedFragments());
+    REQUIRE(sizeof(CanardTxQueueItem) * 2 == ins_alloc.getTotalAllocatedAmount());
+
+    // 2. Poll 1st frame @ 10s + 100us
+    //
+    std::size_t total_handler_calls = 0;
+    REQUIRE(1 == que.poll(ins, now + 100, [&](auto deadline_usec, auto& frame) -> std::int8_t {
+        //
+        ++total_handler_calls;
+        REQUIRE(deadline_usec == now + deadline);
+        REQUIRE(frame.payload.size == 8);
+        REQUIRE(frame.payload.allocated_size == 8);
+        REQUIRE(0 == std::memcmp(frame.payload.data, payload.data(), 7));
+        return 1;
+    }));
+    REQUIRE(1 == total_handler_calls);
+    REQUIRE(1 == que.getSize());
+    REQUIRE(1 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(4 == tx_alloc.getTotalAllocatedAmount());
+    REQUIRE(1 == ins_alloc.getNumAllocatedFragments());
+    REQUIRE(sizeof(CanardTxQueueItem) * 1 == ins_alloc.getTotalAllocatedAmount());
+    REQUIRE(0 == que.getInstance().stats.dropped_frames);
+
+    // 3. Poll 2nd frame @ 10s + 200us
+    //
+    REQUIRE(1 == que.poll(ins, now + 200, [&](auto deadline_usec, auto& frame) -> std::int8_t {
+        //
+        ++total_handler_calls;
+        REQUIRE(deadline_usec == now + deadline);
+        REQUIRE(frame.payload.size == 4);
+        REQUIRE(frame.payload.allocated_size == 4);
+        REQUIRE(0 == std::memcmp(frame.payload.data, payload.data() + 7, 1));
+        return 1;
+    }));
+    REQUIRE(2 == total_handler_calls);
+    REQUIRE(0 == que.getSize());
+    REQUIRE(0 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(0 == tx_alloc.getTotalAllocatedAmount());
+    REQUIRE(0 == ins_alloc.getNumAllocatedFragments());
+    REQUIRE(sizeof(CanardTxQueueItem) * 0 == ins_alloc.getTotalAllocatedAmount());
+    REQUIRE(0 == que.getInstance().stats.dropped_frames);
+}
+
+TEST_CASE("TxPollDropFrameOnFailure")
+{
+    helpers::Instance ins;
+    helpers::TxQueue  que{2, CANARD_MTU_CAN_FD};  // Limit capacity at 2 frames.
+
+    que.setMTU(8);
+    ins.setNodeID(42);
+
+    auto& tx_alloc  = que.getAllocator();
+    auto& ins_alloc = ins.getAllocator();
+
+    std::array<std::uint8_t, 1024> payload{};
+    std::iota(payload.begin(), payload.end(), 0U);
+
+    REQUIRE(42 == ins.getNodeID());
+    REQUIRE(CANARD_MTU_CAN_CLASSIC == que.getMTU());
+    REQUIRE(0 == que.getSize());
+    REQUIRE(0 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(0 == ins_alloc.getNumAllocatedFragments());
+
+    constexpr CanardMicrosecond now      = 10'000'000ULL;  // 10s
+    constexpr CanardMicrosecond deadline = 1'000'000ULL;   // 1s
+
+    CanardTransferMetadata meta{};
+
+    // 1. Push two frames @ 10s
+    //
+    meta.priority       = CanardPriorityNominal;
+    meta.transfer_kind  = CanardTransferKindMessage;
+    meta.port_id        = 321;
+    meta.remote_node_id = CANARD_NODE_ID_UNSET;
+    meta.transfer_id    = 21;
+    REQUIRE(2 == que.push(&ins.getInstance(), now + deadline, meta, {8, payload.data()}, now));
+    REQUIRE(2 == que.getSize());
+    REQUIRE(2 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(8 + 4 == tx_alloc.getTotalAllocatedAmount());
+    REQUIRE(2 == ins_alloc.getNumAllocatedFragments());
+    REQUIRE(sizeof(CanardTxQueueItem) * 2 == ins_alloc.getTotalAllocatedAmount());
+
+    // 2. Poll 1st frame; emulate media failure @ 10s + 100us
+    //
+    std::size_t total_handler_calls = 0;
+    REQUIRE(-1 == que.poll(ins, now + 100, [&](auto deadline_usec, auto& frame) -> std::int8_t {
+        //
+        ++total_handler_calls;
+        REQUIRE(deadline_usec == now + deadline);
+        REQUIRE(frame.payload.size == 8);
+        REQUIRE(frame.payload.allocated_size == 8);
+        REQUIRE(0 == std::memcmp(frame.payload.data, payload.data(), 7));
+        return -1;
+    }));
+    REQUIRE(1 == total_handler_calls);
+    REQUIRE(0 == que.getSize());
+    REQUIRE(0 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(0 == tx_alloc.getTotalAllocatedAmount());
+    REQUIRE(0 == ins_alloc.getNumAllocatedFragments());
+    REQUIRE(sizeof(CanardTxQueueItem) * 0 == ins_alloc.getTotalAllocatedAmount());
+    REQUIRE(2 == que.getInstance().stats.dropped_frames);
+}
+
+TEST_CASE("TxPollDropExpired")
+{
+    helpers::Instance ins;
+    helpers::TxQueue  que{2, CANARD_MTU_CAN_FD};  // Limit capacity at 2 frames.
+
+    que.setMTU(8);
+    ins.setNodeID(42);
+
+    auto& tx_alloc  = que.getAllocator();
+    auto& ins_alloc = ins.getAllocator();
+
+    std::array<std::uint8_t, 1024> payload{};
+    std::iota(payload.begin(), payload.end(), 0U);
+
+    REQUIRE(42 == ins.getNodeID());
+    REQUIRE(CANARD_MTU_CAN_CLASSIC == que.getMTU());
+    REQUIRE(0 == que.getSize());
+    REQUIRE(0 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(0 == ins_alloc.getNumAllocatedFragments());
+
+    CanardMicrosecond           now      = 10'000'000ULL;  // 10s
+    constexpr CanardMicrosecond deadline = 1'000'000ULL;   // 1s
+
+    CanardTransferMetadata meta{};
+
+    // 1. Push nominal priority frame @ 10s
+    //
+    meta.priority       = CanardPriorityNominal;
+    meta.transfer_kind  = CanardTransferKindMessage;
+    meta.port_id        = 321;
+    meta.remote_node_id = CANARD_NODE_ID_UNSET;
+    meta.transfer_id    = 21;
+    REQUIRE(1 == que.push(&ins.getInstance(), now + deadline, meta, {7, payload.data()}, now));
+    REQUIRE(1 == que.getSize());
+    REQUIRE(1 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(8 == tx_alloc.getTotalAllocatedAmount());
+    REQUIRE(1 == ins_alloc.getNumAllocatedFragments());
+    REQUIRE(sizeof(CanardTxQueueItem) * 1 == ins_alloc.getTotalAllocatedAmount());
+
+    // 2. Push high priority frame @ 10s + 1'000us
+    //
+    meta.priority      = CanardPriorityHigh;
+    meta.transfer_kind = CanardTransferKindMessage;
+    meta.port_id       = 321;
+    meta.transfer_id   = 22;
+    REQUIRE(1 == que.push(&ins.getInstance(), now + deadline - 1, meta, {7, payload.data() + 100}, now + 1'000));
+    REQUIRE(2 == que.getSize());
+    REQUIRE(2 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(8 + 8 == tx_alloc.getTotalAllocatedAmount());
+    REQUIRE(2 == ins_alloc.getNumAllocatedFragments());
+    REQUIRE(sizeof(CanardTxQueueItem) * 2 == ins_alloc.getTotalAllocatedAmount());
+
+    // 3. Poll a frame (should be the high priority one); emulate media is busy @ 10s + 2'000us
+    //
+    std::size_t total_handler_calls = 0;
+    REQUIRE(0 == que.poll(ins, now + 2'000, [&](auto deadline_usec, auto& frame) -> std::int8_t {
+        //
+        ++total_handler_calls;
+        REQUIRE(deadline_usec == now + deadline - 1);
+        REQUIRE(frame.payload.size == 8);
+        REQUIRE(frame.payload.allocated_size == 8);
+        REQUIRE(0 == std::memcmp(frame.payload.data, payload.data() + 100, 7));
+        return 0;
+    }));
+    REQUIRE(1 == total_handler_calls);
+    REQUIRE(2 == que.getSize());
+    REQUIRE(2 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(8 + 8 == tx_alloc.getTotalAllocatedAmount());
+    REQUIRE(2 == ins_alloc.getNumAllocatedFragments());
+    REQUIRE(sizeof(CanardTxQueueItem) * 2 == ins_alloc.getTotalAllocatedAmount());
+    REQUIRE(0 == que.getInstance().stats.dropped_frames);
+
+    // 3. Poll a frame (should be nominal priority one b/c the high has been expired) @ 10s + deadline
+    //
+    REQUIRE(1 == que.poll(ins, now + deadline, [&](auto deadline_usec, auto& frame) -> std::int8_t {
+        //
+        ++total_handler_calls;
+        REQUIRE(deadline_usec == now + deadline);
+        REQUIRE(frame.payload.size == 8);
+        REQUIRE(frame.payload.allocated_size == 8);
+        REQUIRE(0 == std::memcmp(frame.payload.data, payload.data(), 7));
+        return 1;
+    }));
+    REQUIRE(2 == total_handler_calls);
+    REQUIRE(0 == que.getSize());
+    REQUIRE(0 == tx_alloc.getNumAllocatedFragments());
+    REQUIRE(0 == tx_alloc.getTotalAllocatedAmount());
+    REQUIRE(0 == ins_alloc.getNumAllocatedFragments());
+    REQUIRE(sizeof(CanardTxQueueItem) * 0 == ins_alloc.getTotalAllocatedAmount());
+    REQUIRE(1 == que.getInstance().stats.dropped_frames);
 }

--- a/tests/test_self.cpp
+++ b/tests/test_self.cpp
@@ -30,7 +30,7 @@ TEST_CASE("TestAllocator")
     REQUIRE(3 == al.getNumAllocatedFragments());
     REQUIRE(600 == al.getTotalAllocatedAmount());
 
-    al.deallocate(a);
+    al.deallocate(a, 123);
     REQUIRE(2 == al.getNumAllocatedFragments());
     REQUIRE(477 == al.getTotalAllocatedAmount());
 
@@ -38,15 +38,15 @@ TEST_CASE("TestAllocator")
     REQUIRE(3 == al.getNumAllocatedFragments());
     REQUIRE(577 == al.getTotalAllocatedAmount());
 
-    al.deallocate(c);
+    al.deallocate(c, 21);
     REQUIRE(2 == al.getNumAllocatedFragments());
     REQUIRE(556 == al.getTotalAllocatedAmount());
 
-    al.deallocate(d);
+    al.deallocate(d, 100);
     REQUIRE(1 == al.getNumAllocatedFragments());
     REQUIRE(456 == al.getTotalAllocatedAmount());
 
-    al.deallocate(b);
+    al.deallocate(b, 456);
     REQUIRE(0 == al.getNumAllocatedFragments());
     REQUIRE(0 == al.getTotalAllocatedAmount());
 }


### PR DESCRIPTION
I want to keep the upcoming v4 changes on the main branch for visibility. We are not going to be publishing this release yet, though.

Changes:

- Fixed issue #216 (#233):
  - Extended `CanardTxQueueItem` with extra `allocated_size` field to remember original size allocated for the item (and its embedded payload).
  - Extended `CanardRxTransfer` with extra `allocated_size` field to report to the client original size allocated for the payload buffer (which is normally equal to session `extent`).

- New memory API for the TX pipeline only -- #225 #234 (not RX yet). Introduced new memory related types:
  - `CanardMemoryAllocate`
  - `CanardMemoryDeallocate`
  - `CanardMemoryDeleter`
  - `CanardMemoryResource`

- Fix potential memory leak in tests

- Introduce CanardPayload #235 
  - added `struct CanardPayload` to combine payload size and data.
  - added `struct CanardMutablePayload` to combine payload size, data and
`allocated_size`.

- `canardTxPeek` now returns mutable item - needed for payload ownership transfer. #236

- Eliminated elaborated type typedefs. #237

- Introduce deadline queue #238

- Introduce TX polling helper #239